### PR TITLE
Add role annotations

### DIFF
--- a/src/Data/Primitive/Unlifted/Array.hs
+++ b/src/Data/Primitive/Unlifted/Array.hs
@@ -86,9 +86,11 @@ import qualified GHC.ST as ST
 
 data MutableUnliftedArray s a
   = MutableUnliftedArray (MutableArrayArray# s)
+type role MutableUnliftedArray nominal representational
 
 data UnliftedArray a
   = UnliftedArray ArrayArray#
+type role UnliftedArray representational
 
 -- | Creates a new 'MutableUnliftedArray'. This function is unsafe because it
 -- initializes all elements of the array as pointers to the array itself. Attempting

--- a/src/Data/Primitive/Unlifted/Array.hs
+++ b/src/Data/Primitive/Unlifted/Array.hs
@@ -4,6 +4,7 @@
 {-# language ScopedTypeVariables #-}
 {-# language TypeFamilies #-}
 {-# language UnboxedTuples #-}
+{-# language RoleAnnotations #-}
 
 -- |
 -- GHC contains three general classes of value types:


### PR DESCRIPTION
The inferred role of the type argument representing the contents is `phantom`, but it should really be `representational`. This ensures type safety for modules not importing the data constructors.