### PR TITLE
Add Array and UnliftedArray instances

### DIFF
--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -24,7 +24,7 @@ library
     Data.Primitive.Unlifted.Class
     Data.Primitive.Unlifted.Array
   build-depends:
-    , base >=4.11.1.0 && <5
+    , base >=4.14.0.0 && <5
     , bytestring >=0.10.8.2 && <0.11
     , primitive >= 0.7 && <0.8
     , text-short >=0.1.3 && <0.2


### PR DESCRIPTION
* Add `PrimUnlifted` instances for `UnliftedArray a` and `MutableUnlifted s a`. These are trivially legitimate, and very important for building trees whose nodes are unlifted arrays.

* Add `PrimUnlifted` instances for `Array` and `MutableArray`. I *hope* these are valid. I assume an `ArrayArray#` is actually
the same as an `Array#` under the hood, and I'm *guessing* the FFI shifts work out. But I don't actually know the situation. This stuff is disgusting.