### PR TITLE
Tear things up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,14 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.8.1"
+    - compiler: "ghc-8.10.1"
       env: GHCHEAD=true
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.8.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.6.5"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.4"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-head"
-      env: GHCHEAD=true
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.2,ghc-8.10.1], sources: [hvr-ghc]}}
+
+# ghc-head seems totally hosed; maybe hvr has quit maintaining it?
+        #    - compiler: "ghc-head"
+        #env: GHCHEAD=true
+        #addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
 
   allow_failures:
 

--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -23,8 +23,10 @@ library
   exposed-modules:
     Data.Primitive.Unlifted.Class
     Data.Primitive.Unlifted.Array
+    Data.Primitive.Unlifted.Array.ST
     Data.Primitive.Unlifted.Array.Base
     Data.Primitive.Unlifted.BoxArray
+    Data.Primitive.Unlifted.BoxArray.ST
     Data.Primitive.Unlifted.Box
   build-depends:
     , base >=4.14.0.0 && <5

--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -23,6 +23,7 @@ library
   exposed-modules:
     Data.Primitive.Unlifted.Class
     Data.Primitive.Unlifted.Array
+    Data.Primitive.Unlifted.Array.Base
   build-depends:
     , base >=4.14.0.0 && <5
     , bytestring >=0.10.8.2 && <0.11

--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -28,11 +28,13 @@ library
     Data.Primitive.Unlifted.BoxArray
     Data.Primitive.Unlifted.BoxArray.ST
     Data.Primitive.Unlifted.Box
+    Data.Primitive.TArray.Classic
   build-depends:
     , base >=4.14.0.0 && <5
     , bytestring >=0.10.8.2 && <0.11
     , primitive >= 0.7 && <0.8
     , text-short >=0.1.3 && <0.2
+    , array
   hs-source-dirs: src
   ghc-options: -Wall -O2
   default-language: Haskell2010

--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -24,6 +24,8 @@ library
     Data.Primitive.Unlifted.Class
     Data.Primitive.Unlifted.Array
     Data.Primitive.Unlifted.Array.Base
+    Data.Primitive.Unlifted.BoxArray
+    Data.Primitive.Unlifted.Box
   build-depends:
     , base >=4.14.0.0 && <5
     , bytestring >=0.10.8.2 && <0.11

--- a/src/Data/Primitive/TArray/Classic.hs
+++ b/src/Data/Primitive/TArray/Classic.hs
@@ -1,0 +1,86 @@
+{-# language MagicHash #-}
+{-# language MultiParamTypeClasses #-}
+{-# language ScopedTypeVariables #-}
+{-# language BangPatterns #-}
+{-# language FlexibleInstances #-}
+{-# language RoleAnnotations #-}
+{- OPTIONS_GHC -ddump-simpl #-}
+
+
+{- |
+This module is a drop-in replacement for @Control.Concurrent.STM.TArray@
+in the @stm@ package. It has the same fundamental inefficiency of the
+classic @TArray@, but it's a /little/ faster and more compact.
+Specifically, this implementation uses two fewer words of memory
+and one fewer indirection per element.
+We also add an 'MArray' instance for working in 'IO' that the 'stm'
+version lacks.
+-}
+
+module Data.Primitive.TArray.Classic (TArray) where
+import GHC.Conc (STM, TVar, newTVar, readTVar, writeTVar
+                , newTVarIO, readTVarIO, atomically)
+import Data.Primitive.Unlifted.Box
+import Data.Primitive.Unlifted.BoxArray
+import Data.Array.Base (MArray (..))
+import Data.Ix (Ix, rangeSize)
+import GHC.Exts (TVar#, RealWorld)
+
+data TArray i a = TArray {
+    _lb :: !i         -- the lower bound
+  , _ub :: !i         -- the upper bound
+  , range :: !Int    -- A cache of (rangeSize (l, u))
+                     -- used to make sure an index is really in range
+  , arr :: !(BoxArray (TVar# RealWorld a))
+  }
+type role TArray nominal representational
+
+-- This Ix constraint is copied from GHC.Arr, but I don't know
+-- why it's there; we only really need Eq.
+instance Ix i => Eq (TArray i a) where
+  TArray lb1 ub1 range1 arr1 == TArray lb2 ub2 range2 arr2
+    | range1 == 0 = range2 == 0
+    | otherwise = lb1 == lb2 && ub1 == ub2 &&
+        and [fromBox (indexBoxArray arr1 i) == (fromBox (indexBoxArray arr2 i) :: TVar a)
+              | i <- [0 .. range1 - 1]]
+
+
+instance MArray TArray e STM where
+  getBounds (TArray l u _ _) = pure (l, u)
+  newArray b e = do
+    tvs <- rep (rangeSize b) (newTVar e)
+    return $ listTArray b tvs
+  -- The stm version defines newArray_, but the default does the
+  -- same thing.
+  unsafeRead tarr i = readTVar $ fromBox $ indexBoxArray (arr tarr) i
+  unsafeWrite tarr i e = writeTVar (fromBox $ indexBoxArray (arr tarr) i) e
+  getNumElements !tarr = pure (range tarr)
+
+-- | Writes are slow in 'IO'.
+instance MArray TArray e IO where
+  getBounds (TArray l u _ _) = pure (l, u)
+  newArray b e = do
+    tvs <- rep (rangeSize b) (newTVarIO e)
+    return $ listTArray b tvs
+  -- The stm version defines newArray_, but the default does the
+  -- same thing.
+  unsafeRead tarr i = readTVarIO $ fromBox $ indexBoxArray (arr tarr) i
+  unsafeWrite tarr i e = atomically $ writeTVar (fromBox $ indexBoxArray (arr tarr) i) e
+  getNumElements !tarr = pure (range tarr)
+
+-- | Like 'replicateM' but uses an accumulator to prevent stack overflows.
+-- Unlike 'replicateM' the returned list is in reversed order.
+-- This doesn't matter though since this function is only used to create
+-- arrays with identical elements.
+rep :: Monad m => Int -> m a -> m [a]
+rep n m = go n []
+    where
+      go 0 xs = return xs
+      go i xs = do
+          x <- m
+          go (i-1) (x:xs)
+
+listTArray :: Ix i => (i, i) -> [TVar e] -> TArray i e
+listTArray (l, u) tvs = TArray l u n (boxArrayFromListN n (map toBox tvs))
+  where
+    !n = rangeSize (l, u)

--- a/src/Data/Primitive/Unlifted/Array.hs
+++ b/src/Data/Primitive/Unlifted/Array.hs
@@ -36,72 +36,49 @@
 -- that are eligible to be stored.
 module Data.Primitive.Unlifted.Array
   ( -- * Types
-    UnliftedArray(..)
-  , MutableUnliftedArray(..)
+    A.UnliftedArray(..)
+  , A.MutableUnliftedArray(..)
     -- * Operations
   , newUnliftedArray
   , unsafeNewUnliftedArray
-  , sizeofUnliftedArray
-  , sizeofMutableUnliftedArray
-  , sameMutableUnliftedArray
+  , A.sizeofUnliftedArray
+  , A.sizeofMutableUnliftedArray
+  , A.sameMutableUnliftedArray
   , writeUnliftedArray
   , readUnliftedArray
-  , indexUnliftedArray
+  , A.indexUnliftedArray
   , unsafeFreezeUnliftedArray
   , freezeUnliftedArray
   , thawUnliftedArray
   , setUnliftedArray
   , copyUnliftedArray
   , copyMutableUnliftedArray
-  , cloneUnliftedArray
+  , A.cloneUnliftedArray
   , cloneMutableUnliftedArray
-  , emptyUnliftedArray
-  , singletonUnliftedArray
-  , runUnliftedArray
+  , A.emptyUnliftedArray
+  , A.singletonUnliftedArray
+  , A.runUnliftedArray
     -- * List Conversion
-  , unliftedArrayToList
-  , unliftedArrayFromList
-  , unliftedArrayFromListN
+  , A.unliftedArrayToList
+  , A.unliftedArrayFromList
+  , A.unliftedArrayFromListN
     -- * Folding
-  , foldrUnliftedArray
-  , foldrUnliftedArray'
-  , foldlUnliftedArray
-  , foldlUnliftedArray'
-  , foldlUnliftedArrayM'
+  , A.foldrUnliftedArray
+  , A.foldrUnliftedArray'
+  , A.foldlUnliftedArray
+  , A.foldlUnliftedArray'
+  , A.foldlUnliftedArrayM'
     -- * Traversals
-  , traverseUnliftedArray_
-  , itraverseUnliftedArray_
+  , A.traverseUnliftedArray_
+  , A.itraverseUnliftedArray_
     -- * Mapping
-  , mapUnliftedArray
+  , A.mapUnliftedArray
   ) where
 
-import Control.Monad.Primitive (PrimMonad,PrimState,primitive,primitive_)
-import Control.Monad.ST (ST)
+import Control.Monad.Primitive (PrimMonad,PrimState,stToPrim)
 import Data.Primitive.Unlifted.Class (PrimUnlifted (..))
-import Data.Primitive.Unlifted.Array.Base
-import GHC.Exts (Int(I#),State#)
-import qualified GHC.ST as ST
-
-import qualified Data.List as L
-import qualified GHC.Exts as Exts
-
-data UnliftedArray a
-  = UnliftedArray (UnliftedArray# (Unlifted a))
-type role UnliftedArray nominal
-
-data MutableUnliftedArray s a
-  = MutableUnliftedArray (MutableUnliftedArray# s (Unlifted a))
-type role MutableUnliftedArray nominal nominal
-
-instance PrimUnlifted (UnliftedArray a) where
-  type Unlifted (UnliftedArray a) = UnliftedArray# (Unlifted a)
-  toUnlifted# (UnliftedArray a) = a
-  fromUnlifted# x = UnliftedArray x
-
-instance PrimUnlifted (MutableUnliftedArray s a) where
-  type Unlifted (MutableUnliftedArray s a) = MutableUnliftedArray# s (Unlifted a)
-  toUnlifted# (MutableUnliftedArray a) = a
-  fromUnlifted# x = MutableUnliftedArray x
+import Data.Primitive.Unlifted.Array.ST (UnliftedArray, MutableUnliftedArray)
+import qualified Data.Primitive.Unlifted.Array.ST as A
 
 -- | Creates a new 'MutableUnliftedArray' with the specified value as initial
 -- contents.
@@ -110,8 +87,8 @@ newUnliftedArray
   => Int -- ^ size
   -> a -- ^ initial value
   -> m (MutableUnliftedArray (PrimState m) a)
-newUnliftedArray (I# len) v = primitive $ \s -> case newUnliftedArray# len (toUnlifted# v) s of
-  (# s', ma #) -> (# s', MutableUnliftedArray ma #)
+newUnliftedArray len v
+  = stToPrim $ A.newUnliftedArray len v
 {-# inline newUnliftedArray #-}
 
 setUnliftedArray
@@ -122,22 +99,8 @@ setUnliftedArray
   -> Int -- ^ length
   -> m ()
 {-# inline setUnliftedArray #-}
-setUnliftedArray mua v off len = loop (len + off - 1)
- where
- loop i
-   | i < off = pure ()
-   | otherwise = writeUnliftedArray mua i v *> loop (i-1)
-
--- | Yields the length of an 'UnliftedArray'.
-sizeofUnliftedArray :: UnliftedArray e -> Int
-{-# inline sizeofUnliftedArray #-}
-sizeofUnliftedArray (UnliftedArray ar) = I# (sizeofUnliftedArray# ar)
-
--- | Yields the length of a 'MutableUnliftedArray'.
-sizeofMutableUnliftedArray :: MutableUnliftedArray s e -> Int
-{-# inline sizeofMutableUnliftedArray #-}
-sizeofMutableUnliftedArray (MutableUnliftedArray maa#)
-  = I# (sizeofMutableUnliftedArray# maa#)
+setUnliftedArray mua v off len
+  = stToPrim $ A.setUnliftedArray mua v off len
 
 writeUnliftedArray :: (PrimMonad m, PrimUnlifted a)
   => MutableUnliftedArray (PrimState m) a
@@ -145,25 +108,16 @@ writeUnliftedArray :: (PrimMonad m, PrimUnlifted a)
   -> a
   -> m ()
 {-# inline writeUnliftedArray #-}
-writeUnliftedArray (MutableUnliftedArray arr) (I# ix) a =
-  primitive_ (writeUnliftedArray# arr ix (toUnlifted# a))
+writeUnliftedArray arr ix a
+  = stToPrim $ A.writeUnliftedArray arr ix a
 
 readUnliftedArray :: (PrimMonad m, PrimUnlifted a)
   => MutableUnliftedArray (PrimState m) a
   -> Int
   -> m a
 {-# inline readUnliftedArray #-}
-readUnliftedArray (MutableUnliftedArray arr) (I# ix) =
-  primitive $ \s -> case readUnliftedArray# arr ix s of
-    (# s', a #) -> (# s', fromUnlifted# a #)
-
-indexUnliftedArray :: PrimUnlifted a
-  => UnliftedArray a
-  -> Int
-  -> a
-{-# inline indexUnliftedArray #-}
-indexUnliftedArray (UnliftedArray arr) (I# ix) =
-  fromUnlifted# (indexUnliftedArray# arr ix)
+readUnliftedArray arr ix
+  = stToPrim $ A.readUnliftedArray arr ix
 
 -- | Freezes a 'MutableUnliftedArray', yielding an 'UnliftedArray'. This simply
 -- marks the array as frozen in place, so it should only be used when no further
@@ -172,24 +126,13 @@ unsafeFreezeUnliftedArray
   :: PrimMonad m
   => MutableUnliftedArray (PrimState m) a
   -> m (UnliftedArray a)
-unsafeFreezeUnliftedArray (MutableUnliftedArray maa#)
-  = primitive $ \s -> case unsafeFreezeUnliftedArray# maa# s of
-      (# s', aa# #) -> (# s', UnliftedArray aa# #)
+unsafeFreezeUnliftedArray ma
+  = stToPrim $ A.unsafeFreezeUnliftedArray ma
 {-# inline unsafeFreezeUnliftedArray #-}
-
--- | Determines whether two 'MutableUnliftedArray' values are the same. This is
--- object/pointer identity, not based on the contents.
-sameMutableUnliftedArray
-  :: MutableUnliftedArray s a
-  -> MutableUnliftedArray s a
-  -> Bool
-sameMutableUnliftedArray (MutableUnliftedArray maa1#) (MutableUnliftedArray maa2#)
-  = Exts.isTrue# (sameMutableUnliftedArray# maa1# maa2#)
-{-# inline sameMutableUnliftedArray #-}
 
 -- | Copies the contents of an immutable array into a mutable array.
 copyUnliftedArray
-  :: (PrimMonad m)
+  :: PrimMonad m
   => MutableUnliftedArray (PrimState m) a -- ^ destination
   -> Int -- ^ offset into destination
   -> UnliftedArray a -- ^ source
@@ -197,14 +140,12 @@ copyUnliftedArray
   -> Int -- ^ number of elements to copy
   -> m ()
 {-# inline copyUnliftedArray #-}
-copyUnliftedArray
-  (MutableUnliftedArray dst) (I# doff)
-  (UnliftedArray src) (I# soff) (I# ln) =
-    primitive_ $ copyUnliftedArray# src soff dst doff ln
+copyUnliftedArray dst doff src soff ln
+  = stToPrim $ A.copyUnliftedArray dst doff src soff ln
 
 -- | Copies the contents of one mutable array into another.
 copyMutableUnliftedArray
-  :: (PrimMonad m)
+  :: PrimMonad m
   => MutableUnliftedArray (PrimState m) a -- ^ destination
   -> Int -- ^ offset into destination
   -> MutableUnliftedArray (PrimState m) a -- ^ source
@@ -212,23 +153,20 @@ copyMutableUnliftedArray
   -> Int -- ^ number of elements to copy
   -> m ()
 {-# inline copyMutableUnliftedArray #-}
-copyMutableUnliftedArray
-  (MutableUnliftedArray dst) (I# doff)
-  (MutableUnliftedArray src) (I# soff) (I# ln) =
-    primitive_ $ copyMutableUnliftedArray# src soff dst doff ln
+copyMutableUnliftedArray dst doff src soff ln
+  = stToPrim $ A.copyMutableUnliftedArray dst doff src soff ln
 
 -- | Freezes a portion of a 'MutableUnliftedArray', yielding an 'UnliftedArray'.
 -- This operation is safe, in that it copies the frozen portion, and the
 -- existing mutable array may still be used afterward.
 freezeUnliftedArray
-  :: (PrimMonad m)
+  :: PrimMonad m
   => MutableUnliftedArray (PrimState m) a -- ^ source
   -> Int -- ^ offset
   -> Int -- ^ length
   -> m (UnliftedArray a)
-freezeUnliftedArray (MutableUnliftedArray mary) (I# off) (I# len) =
-    primitive $ \s -> case freezeUnliftedArray# mary off len s of
-      (# s', ary #) -> (# s', UnliftedArray ary #)
+freezeUnliftedArray mary off len
+  = stToPrim $ A.freezeUnliftedArray mary off len
 {-# inline freezeUnliftedArray #-}
 
 -- | Thaws a portion of an 'UnliftedArray', yielding a 'MutableUnliftedArray'.
@@ -241,252 +179,29 @@ thawUnliftedArray
   -> Int -- ^ length
   -> m (MutableUnliftedArray (PrimState m) a)
 {-# inline thawUnliftedArray #-}
-thawUnliftedArray (UnliftedArray ary) (I# off) (I# len) =
-    primitive $ \s -> case thawUnliftedArray# ary off len s of
-      (# s', mary #) -> (# s', MutableUnliftedArray mary #)
-
--- | Execute a stateful computation and freeze the resulting array.
-runUnliftedArray
-  :: (forall s. ST s (MutableUnliftedArray s a))
-  -> UnliftedArray a
-{-# INLINE runUnliftedArray #-}
--- This is what we'd like to write, but GHC does not yet
--- produce properly unboxed code when we do
--- runUnliftedArray m = runST $ m >>= unsafeFreezeUnliftedArray
-runUnliftedArray m = UnliftedArray (runUnliftedArray# m)
-
-runUnliftedArray#
-  :: (forall s. ST s (MutableUnliftedArray s a))
-  -> UnliftedArray# (Unlifted a)
-runUnliftedArray# m = case Exts.runRW# $ \s ->
-  case unST m s of { (# s', MutableUnliftedArray mary# #) ->
-  unsafeFreezeUnliftedArray# mary# s'} of (# _, ary# #) -> ary#
-{-# INLINE runUnliftedArray# #-}
-
-unST :: ST s a -> State# s -> (# State# s, a #)
-unST (ST.ST f) = f
-
-unsafeCreateUnliftedArray
-  :: Int
-  -> (forall s. MutableUnliftedArray s a -> ST s ())
-  -> UnliftedArray a
-unsafeCreateUnliftedArray !n f = runUnliftedArray $ do
-  mary <- unsafeNewUnliftedArray n
-  f mary
-  pure mary
+thawUnliftedArray ary off len
+  = stToPrim $ A.thawUnliftedArray ary off len
 
 -- | Creates a new 'MutableUnliftedArray'. This function is unsafe because it
 -- initializes all elements of the array as pointers to the empty array. Attempting
 -- to read one of these elements before writing to it is in effect an unsafe
 -- coercion from @'UnliftedArray' a@ to the element type.
 unsafeNewUnliftedArray
-  :: (PrimMonad m)
+  :: PrimMonad m
   => Int -- ^ size
   -> m (MutableUnliftedArray (PrimState m) a)
 {-# inline unsafeNewUnliftedArray #-}
-unsafeNewUnliftedArray (I# i) = primitive $ \s -> case unsafeNewUnliftedArray# i s of
-  (# s', ma #) -> (# s', MutableUnliftedArray ma #)
-
-
--- | Creates a copy of a portion of an 'UnliftedArray'
-cloneUnliftedArray
-  :: UnliftedArray a -- ^ source
-  -> Int -- ^ offset
-  -> Int -- ^ length
-  -> UnliftedArray a
-{-# inline cloneUnliftedArray #-}
-cloneUnliftedArray (UnliftedArray ary) (I# off) (I# len)
-  = UnliftedArray (cloneUnliftedArray# ary off len)
+unsafeNewUnliftedArray len
+  = stToPrim $ A.unsafeNewUnliftedArray len
 
 -- | Creates a new 'MutableUnliftedArray' containing a copy of a portion of
 -- another mutable array.
 cloneMutableUnliftedArray
-  :: (PrimMonad m)
+  :: PrimMonad m
   => MutableUnliftedArray (PrimState m) a -- ^ source
   -> Int -- ^ offset
   -> Int -- ^ length
   -> m (MutableUnliftedArray (PrimState m) a)
 {-# inline cloneMutableUnliftedArray #-}
-cloneMutableUnliftedArray (MutableUnliftedArray mary) (I# off) (I# len)
-  = primitive $ \s -> case cloneMutableUnliftedArray# mary off len s of
-      (# s', mary' #) -> (# s', MutableUnliftedArray mary' #)
-
-emptyUnliftedArray :: UnliftedArray a
-emptyUnliftedArray = UnliftedArray (emptyUnliftedArray# Exts.void#)
-
-singletonUnliftedArray :: PrimUnlifted a => a -> UnliftedArray a
-{-# INLINE singletonUnliftedArray #-}
-singletonUnliftedArray x = runUnliftedArray $ newUnliftedArray 1 x
-
-concatUnliftedArray :: UnliftedArray a -> UnliftedArray a -> UnliftedArray a
-{-# INLINE concatUnliftedArray #-}
-concatUnliftedArray (UnliftedArray a1) (UnliftedArray a2)
-  = UnliftedArray (concatUnliftedArray# a1 a2)
-
--- This junk is to make sure we unbox properly. Inlining this doesn't seem
--- likely to be much of a win ever, and could potentially lead to reboxing,
--- so we NOINLINE. It would be nice to find a prettier way to do this.
-concatUnliftedArray# :: UnliftedArray# a -> UnliftedArray# a -> UnliftedArray# a
-{-# NOINLINE concatUnliftedArray# #-}
-concatUnliftedArray# a1 a2 =
-  let !sza1 = sizeofUnliftedArray# a1
-  in
-    if Exts.isTrue# (sza1 Exts.==# 0#)
-    then a2
-    else
-      let !sza2 = sizeofUnliftedArray# a2
-      in
-        if Exts.isTrue# (sza2 Exts.==# 0#)
-        then a1
-        else Exts.runRW# $ \s ->
-          case unsafeNewUnliftedArray# (sza1 Exts.+# sza2) s of { (# s', ma #) ->
-          case copyUnliftedArray# a1 0# ma 0# sza1 s' of { s'' ->
-          case copyUnliftedArray# a2 0# ma sza1 sza2 s'' of { s''' ->
-          case unsafeFreezeUnliftedArray# ma s''' of
-            (# _, ar #) -> ar}}}
-
-foldrUnliftedArray :: forall a b. PrimUnlifted a => (a -> b -> b) -> b -> UnliftedArray a -> b
-{-# INLINE foldrUnliftedArray #-}
-foldrUnliftedArray f z arr = go 0
-  where
-    !sz = sizeofUnliftedArray arr
-    go !i
-      | sz > i = f (indexUnliftedArray arr i) (go (i+1))
-      | otherwise = z
-
--- | Strict right-associated fold over the elements of an 'UnliftedArray.
-{-# INLINE foldrUnliftedArray' #-}
-foldrUnliftedArray' :: forall a b. PrimUnlifted a => (a -> b -> b) -> b -> UnliftedArray a -> b
-foldrUnliftedArray' f z0 arr = go (sizeofUnliftedArray arr - 1) z0
-  where
-    go !i !acc
-      | i < 0 = acc
-      | otherwise = go (i - 1) (f (indexUnliftedArray arr i) acc)
-
--- | Lazy left-associated fold over the elements of an 'UnliftedArray'.
-{-# INLINE foldlUnliftedArray #-}
-foldlUnliftedArray :: forall a b. PrimUnlifted a => (b -> a -> b) -> b -> UnliftedArray a -> b
-foldlUnliftedArray f z arr = go (sizeofUnliftedArray arr - 1)
-  where
-    go !i
-      | i < 0 = z
-      | otherwise = f (go (i - 1)) (indexUnliftedArray arr i)
-
--- | Strict left-associated fold over the elements of an 'UnliftedArray'.
-{-# INLINE foldlUnliftedArray' #-}
-foldlUnliftedArray' :: forall a b. PrimUnlifted a => (b -> a -> b) -> b -> UnliftedArray a -> b
-foldlUnliftedArray' f z0 arr = go 0 z0
-  where
-    !sz = sizeofUnliftedArray arr
-    go !i !acc
-      | i < sz = go (i + 1) (f acc (indexUnliftedArray arr i))
-      | otherwise = acc
-
--- | Strict effectful left-associated fold over the elements of an 'UnliftedArray'.
-{-# INLINE foldlUnliftedArrayM' #-}
-foldlUnliftedArrayM' :: (PrimUnlifted a, Monad m)
-  => (b -> a -> m b) -> b -> UnliftedArray a -> m b
-foldlUnliftedArrayM' f z0 arr = go 0 z0
-  where
-    !sz = sizeofUnliftedArray arr
-    go !i !acc
-      | i < sz = f acc (indexUnliftedArray arr i) >>= go (i + 1) 
-      | otherwise = pure acc
-
--- | Effectfully traverse the elements of an 'UnliftedArray', discarding
--- the resulting values.
-{-# INLINE traverseUnliftedArray_ #-}
-traverseUnliftedArray_ :: (PrimUnlifted a, Applicative m)
-  => (a -> m b) -> UnliftedArray a -> m ()
-traverseUnliftedArray_ f arr = go 0
-  where
-    !sz = sizeofUnliftedArray arr
-    go !i
-      | i < sz = f (indexUnliftedArray arr i) *> go (i + 1) 
-      | otherwise = pure ()
-
--- | Effectful indexed traversal of the elements of an 'UnliftedArray',
--- discarding the resulting values.
-{-# INLINE itraverseUnliftedArray_ #-}
-itraverseUnliftedArray_ :: (PrimUnlifted a, Applicative m)
-  => (Int -> a -> m b) -> UnliftedArray a -> m ()
-itraverseUnliftedArray_ f arr = go 0
-  where
-    !sz = sizeofUnliftedArray arr
-    go !i
-      | i < sz = f i (indexUnliftedArray arr i) *> go (i + 1) 
-      | otherwise = pure ()
-
--- | Map over the elements of an 'UnliftedArray'.
-{-# INLINE mapUnliftedArray #-}
-mapUnliftedArray :: (PrimUnlifted a, PrimUnlifted b)
-  => (a -> b)
-  -> UnliftedArray a
-  -> UnliftedArray b
-mapUnliftedArray f arr = unsafeCreateUnliftedArray sz $ \marr -> do
-  let go !ix = if ix < sz
-        then do
-          let b = f (indexUnliftedArray arr ix)
-          writeUnliftedArray marr ix b
-          go (ix + 1)
-        else return ()
-  go 0
-  where
-  !sz = sizeofUnliftedArray arr
-
--- | Convert the unlifted array to a list.
-{-# INLINE unliftedArrayToList #-}
-unliftedArrayToList :: PrimUnlifted a => UnliftedArray a -> [a]
-unliftedArrayToList xs = Exts.build (\c n -> foldrUnliftedArray c n xs)
-
-unliftedArrayFromList :: PrimUnlifted a => [a] -> UnliftedArray a
-unliftedArrayFromList xs = unliftedArrayFromListN (L.length xs) xs
-
-unliftedArrayFromListN :: forall a. PrimUnlifted a => Int -> [a] -> UnliftedArray a
-unliftedArrayFromListN len vs = unsafeCreateUnliftedArray len run where
-  run :: forall s. MutableUnliftedArray s a -> ST s ()
-  run arr = do
-    let go :: [a] -> Int -> ST s ()
-        go [] !ix = if ix == len
-          -- The size check is mandatory since failure to initialize all elements
-          -- introduces the possibility of a segfault happening when someone attempts
-          -- to read the unitialized element. See the docs for unsafeNewUnliftedArray.
-          then return ()
-          else die "unliftedArrayFromListN" "list length less than specified size"
-        go (a : as) !ix = if ix < len
-          then do
-            writeUnliftedArray arr ix a
-            go as (ix + 1)
-          else die "unliftedArrayFromListN" "list length greater than specified size"
-    go vs 0
-
-instance PrimUnlifted a => Exts.IsList (UnliftedArray a) where
-  type Item (UnliftedArray a) = a
-  fromList = unliftedArrayFromList
-  fromListN = unliftedArrayFromListN
-  toList = unliftedArrayToList
-
-instance Semigroup (UnliftedArray a) where
-  (<>) = concatUnliftedArray
-
-instance Monoid (UnliftedArray a) where
-  mempty = emptyUnliftedArray
-
-instance (Show a, PrimUnlifted a) => Show (UnliftedArray a) where
-  showsPrec p a = showParen (p > 10) $
-    showString "fromListN " . shows (sizeofUnliftedArray a) . showString " "
-      . shows (unliftedArrayToList a)
-
-instance Eq (MutableUnliftedArray s a) where
-  (==) = sameMutableUnliftedArray
-
-instance (Eq a, PrimUnlifted a) => Eq (UnliftedArray a) where
-  aa1 == aa2 = sizeofUnliftedArray aa1 == sizeofUnliftedArray aa2
-            && loop (sizeofUnliftedArray aa1 - 1)
-   where
-   loop i
-     | i < 0 = True
-     | otherwise = indexUnliftedArray aa1 i == indexUnliftedArray aa2 i && loop (i-1)
-
-die :: String -> String -> a
-die fun problem = error $ "Data.Primitive.UnliftedArray." ++ fun ++ ": " ++ problem
+cloneMutableUnliftedArray mary off len
+  = stToPrim $ A.cloneMutableUnliftedArray mary off len

--- a/src/Data/Primitive/Unlifted/Array.hs
+++ b/src/Data/Primitive/Unlifted/Array.hs
@@ -466,10 +466,10 @@ instance PrimUnlifted a => Exts.IsList (UnliftedArray a) where
   fromListN = unliftedArrayFromListN
   toList = unliftedArrayToList
 
-instance PrimUnlifted a => Semigroup (UnliftedArray a) where
+instance Semigroup (UnliftedArray a) where
   (<>) = concatUnliftedArray
 
-instance PrimUnlifted a => Monoid (UnliftedArray a) where
+instance Monoid (UnliftedArray a) where
   mempty = emptyUnliftedArray
 
 instance (Show a, PrimUnlifted a) => Show (UnliftedArray a) where

--- a/src/Data/Primitive/Unlifted/Array/Base.hs
+++ b/src/Data/Primitive/Unlifted/Array/Base.hs
@@ -1,0 +1,185 @@
+{-# language MagicHash #-}
+{-# language UnboxedTuples #-}
+{-# language RoleAnnotations #-}
+{-# language UnliftedNewtypes #-}
+{-# language KindSignatures #-}
+-- |
+-- Primitive types representing unlifted arrays and the
+-- primops for manipulating them.
+module Data.Primitive.Unlifted.Array.Base
+  ( -- * Types
+    UnliftedArray#
+  , MutableUnliftedArray#
+    -- We don't export the newtype constructors because they're bogus and
+    -- because there's basically no reason they'd ever be used. This module
+    -- contains a wrapped version of every Array# primop.  Eventually, all this
+    -- stuff will be in GHC.Prim, possibly with other names.
+
+    -- * Operations
+  , newUnliftedArray#
+  , unsafeNewUnliftedArray#
+  , emptyUnliftedArray#
+  , sameMutableUnliftedArray#
+  , readUnliftedArray#
+  , writeUnliftedArray#
+  , sizeofUnliftedArray#
+  , sizeofMutableUnliftedArray#
+  , indexUnliftedArray#
+  , unsafeFreezeUnliftedArray#
+  , unsafeThawUnliftedArray#
+  , copyUnliftedArray#
+  , copyMutableUnliftedArray#
+  , cloneUnliftedArray#
+  , cloneMutableUnliftedArray#
+  , freezeUnliftedArray#
+  , thawUnliftedArray#
+  , casUnliftedArray#
+  ) where
+
+import GHC.Exts (Int#,State#,Array#,MutableArray#,Any,TYPE,RuntimeRep(UnliftedRep),unsafeCoerce#)
+import qualified GHC.Exts as Exts
+
+newtype UnliftedArray# (a :: TYPE 'UnliftedRep) = UnliftedArray# (Array# Any)
+type role UnliftedArray# representational
+
+newtype MutableUnliftedArray# s (a :: TYPE 'UnliftedRep) = MutableUnliftedArray# (MutableArray# s Any)
+type role MutableUnliftedArray# nominal representational
+
+newUnliftedArray# :: Int# -> a -> State# s -> (# State# s, MutableUnliftedArray# s a #)
+newUnliftedArray# sz a s = case Exts.newArray# sz (unsafeCoerce# a) s of
+  (# s', mary #) -> (# s', MutableUnliftedArray# mary #)
+{-# INLINE newUnliftedArray# #-}
+
+-- | Create a 'MutableUnliftedArray#' whose entries contain some unspecified
+-- static value. This may be more convenient than 'newUnliftedArray#' if there
+-- is no value on hand with which to initialize the array. Each entry must be
+-- initialized before being read and used. This condition is not checked.
+unsafeNewUnliftedArray# :: Int# -> State# s -> (# State# s, MutableUnliftedArray# s a #)
+-- We fill the array with the Nonsense data constructor. It doesn't much matter
+-- *what* we stick in there, as long as it's a pointer the garbage collector
+-- can understand and isn't something that might otherwise be released as garbage.
+-- There's no point trying to stick an `error` in there, because there's no
+-- code anywhere to force the error thunk.
+unsafeNewUnliftedArray# sz s = case Exts.newArray# sz (unsafeCoerce# Nonsense) s of
+  (# s', mary #) -> (# s', MutableUnliftedArray# mary #)
+{-# INLINE unsafeNewUnliftedArray# #-}
+
+data Nonsense = Nonsense
+
+
+-- This represents a *statically allocated* value, preferably in a *read-only*
+-- segment of memory.
+--
+-- Why do we bother to noDuplicate#? It generally doesn't much *matter* if
+-- different threads have different global empty arrays. However, for
+-- performance testing purposes, a user may well want to check whether the
+-- empty arrays they expect to be the global ones really are. Such a test
+-- is only possible if there's just *one* array to test against. The overhead
+-- of the once-ever noDuplicate# call is sure to be trivial anyway.
+empty_unlifted_array :: ULA a
+empty_unlifted_array = ULA
+  (Exts.runRW# $ \s ->
+    case Exts.noDuplicate# s of { s' ->
+    case Exts.newArray# 0# (unsafeCoerce# Nonsense) s' of { (# s'', mary #) ->
+    case Exts.unsafeFreezeArray# mary s'' of { (# _, ary #) ->
+      UnliftedArray# ary }}})
+{-# NOINLINE empty_unlifted_array #-}
+
+data ULA a = ULA (UnliftedArray# a)
+
+-- | Warning: Applying 'unsafeThawUnliftedArray#' to the array produced by
+-- this function will make demons come out of your nose.
+emptyUnliftedArray# :: Exts.Void# -> UnliftedArray# a
+-- We make this primitive because it's the easiest way to get a
+-- *shared* primitive unlifted array.
+--
+-- Why the stern warning above? GHC does not currently support resizing 'Array#',
+-- and does not really meaningfully support *growing* arrays of any type. If,
+-- however, that ever changes, growing the globally shared empty array would be
+-- pretty disastrous.
+emptyUnliftedArray# _ = case empty_unlifted_array of
+  ULA ary -> ary
+{-# INLINE emptyUnliftedArray# #-}
+
+sameMutableUnliftedArray# :: MutableUnliftedArray# s a -> MutableUnliftedArray# s a -> Int#
+sameMutableUnliftedArray# (MutableUnliftedArray# ar1) (MutableUnliftedArray# ar2)
+  = Exts.sameMutableArray# ar1 ar2
+{-# INLINE sameMutableUnliftedArray# #-}
+
+readUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> State# s -> (# State# s, a #)
+readUnliftedArray# (MutableUnliftedArray# mary) i s
+  = case Exts.readArray# mary i s
+      of (# s', a #) -> (# s', unsafeCoerce# a #)
+{-# INLINE readUnliftedArray# #-}
+
+writeUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> a -> State# s -> State# s
+writeUnliftedArray# (MutableUnliftedArray# mary) i a s
+  = Exts.writeArray# mary i (unsafeCoerce# a) s
+{-# INLINE writeUnliftedArray# #-}
+
+sizeofUnliftedArray# :: UnliftedArray# a -> Int#
+sizeofUnliftedArray# (UnliftedArray# ary) = Exts.sizeofArray# ary
+{-# INLINE sizeofUnliftedArray# #-}
+
+sizeofMutableUnliftedArray# :: MutableUnliftedArray# s a -> Int#
+sizeofMutableUnliftedArray# (MutableUnliftedArray# mary)
+  = Exts.sizeofMutableArray# mary
+{-# INLINE sizeofMutableUnliftedArray# #-}
+
+indexUnliftedArray# :: UnliftedArray# a -> Int# -> a
+indexUnliftedArray# (UnliftedArray# ary) i
+  | (# a #) <- Exts.indexArray# ary i
+  = unsafeCoerce# a
+{-# INLINE indexUnliftedArray# #-}
+
+unsafeFreezeUnliftedArray# :: MutableUnliftedArray# s a -> State# s -> (# State# s, UnliftedArray# a #)
+unsafeFreezeUnliftedArray# (MutableUnliftedArray# mary) s
+  = case Exts.unsafeFreezeArray# mary s of
+      (# s', ary #) -> (# s', UnliftedArray# ary #)
+{-# INLINE unsafeFreezeUnliftedArray# #-}
+
+unsafeThawUnliftedArray# :: UnliftedArray# a -> State# s -> (# State# s, MutableUnliftedArray# s a #)
+unsafeThawUnliftedArray# (UnliftedArray# ary) s
+  = case Exts.unsafeThawArray# ary s of
+     (# s', mary #) -> (# s', MutableUnliftedArray# mary #)
+{-# INLINE unsafeThawUnliftedArray# #-}
+
+copyUnliftedArray# :: UnliftedArray# a -> Int# -> MutableUnliftedArray# s a -> Int# -> Int# -> State# s -> State# s
+copyUnliftedArray# (UnliftedArray# ary) i1 (MutableUnliftedArray# mary) i2 n s
+  = Exts.copyArray# ary i1 mary i2 n s
+{-# INLINE copyUnliftedArray# #-}
+
+copyMutableUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> MutableUnliftedArray# s a -> Int# -> Int# -> State# s -> State# s
+copyMutableUnliftedArray# (MutableUnliftedArray# mary1) i1 (MutableUnliftedArray# mary2) i2 n s
+  = Exts.copyMutableArray# mary1 i1 mary2 i2 n s
+{-# INLINE copyMutableUnliftedArray# #-}
+
+cloneUnliftedArray# :: UnliftedArray# a -> Int# -> Int# -> UnliftedArray# a
+cloneUnliftedArray# (UnliftedArray# ary) i n
+  = UnliftedArray# (Exts.cloneArray# ary i n)
+{-# INLINE cloneUnliftedArray# #-}
+
+cloneMutableUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> Int# -> State# s
+  -> (# State# s, MutableUnliftedArray# s a #)
+cloneMutableUnliftedArray# (MutableUnliftedArray# mary) i n s
+  = case Exts.cloneMutableArray# mary i n s of
+      (# s', mary' #) -> (# s', MutableUnliftedArray# mary' #)
+{-# INLINE cloneMutableUnliftedArray# #-}
+
+freezeUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> Int# -> State# s -> (# State# s, UnliftedArray# a #)
+freezeUnliftedArray# (MutableUnliftedArray# mary) i n s
+  = case Exts.freezeArray# mary i n s of
+      (# s', ary #) -> (# s', UnliftedArray# ary #)
+{-# INLINE freezeUnliftedArray# #-}
+
+thawUnliftedArray# :: UnliftedArray# a -> Int# -> Int# -> State# s -> (# State# s, MutableUnliftedArray# s a #)
+thawUnliftedArray# (UnliftedArray# ary) i n s
+  = case Exts.thawArray# ary i n s of
+      (# s', mary #) -> (# s', MutableUnliftedArray# mary #)
+{-# INLINE thawUnliftedArray# #-}
+
+casUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> a -> a -> State# s -> (# State# s, Int#, a #)
+casUnliftedArray# (MutableUnliftedArray# mary) i x y s
+  = case Exts.casArray# mary i (unsafeCoerce# x) (unsafeCoerce# y) s of
+      (# s', sf, a #) -> (# s', sf, unsafeCoerce# a #)
+{-# INLINE casUnliftedArray# #-}

--- a/src/Data/Primitive/Unlifted/Array/ST.hs
+++ b/src/Data/Primitive/Unlifted/Array/ST.hs
@@ -1,0 +1,384 @@
+{-# language BangPatterns #-}
+{-# language MagicHash #-}
+{-# language RankNTypes #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeFamilies #-}
+{-# language UnboxedTuples #-}
+{-# language RoleAnnotations #-}
+{- OPTIONS_GHC -ddump-simpl #-}
+
+-- |
+-- GHC contains three general classes of value types:
+--
+--   1. Unboxed types: values are machine values made up of fixed numbers of bytes
+--   2. Unlifted types: values are pointers, but strictly evaluated
+--   3. Lifted types: values are pointers, lazily evaluated
+--
+-- The first category can be stored in a 'ByteArray', and this allows types in
+-- category 3 that are simple wrappers around category 1 types to be stored
+-- more efficiently using a 'ByteArray'. This module provides the same facility
+-- for category 2 types.
+--
+-- GHC has two primitive types, 'ArrayArray#' and 'MutableArrayArray#'. These
+-- are arrays of pointers, but of category 2 values, so they are known to not
+-- be bottom. This allows types that are wrappers around such types to be stored
+-- in an array without an extra level of indirection.
+--
+-- The way that the 'ArrayArray#' API works is that one can read and write
+-- 'ArrayArray#' values to the positions. This works because all category 2
+-- types share a uniform representation, unlike unboxed values which are
+-- represented by varying (by type) numbers of bytes. However, using the
+-- this makes the internal API very unsafe to use, as one has to coerce values
+-- to and from 'ArrayArray#'.
+--
+-- The API presented by this module is more type safe. 'UnliftedArray' and
+-- 'MutableUnliftedArray' are parameterized by the type of arrays they contain, and
+-- the coercions necessary are abstracted into a class, 'PrimUnlifted', of things
+-- that are eligible to be stored.
+module Data.Primitive.Unlifted.Array.ST
+  ( -- * Types
+    UnliftedArray(..)
+  , MutableUnliftedArray(..)
+    -- * Operations
+  , newUnliftedArray
+  , unsafeNewUnliftedArray
+  , sizeofUnliftedArray
+  , sizeofMutableUnliftedArray
+  , sameMutableUnliftedArray
+  , writeUnliftedArray
+  , readUnliftedArray
+  , indexUnliftedArray
+  , unsafeFreezeUnliftedArray
+  , freezeUnliftedArray
+  , thawUnliftedArray
+  , setUnliftedArray
+  , copyUnliftedArray
+  , copyMutableUnliftedArray
+  , cloneUnliftedArray
+  , cloneMutableUnliftedArray
+  , emptyUnliftedArray
+  , singletonUnliftedArray
+  , runUnliftedArray
+    -- * List Conversion
+  , unliftedArrayToList
+  , unliftedArrayFromList
+  , unliftedArrayFromListN
+    -- * Folding
+  , foldrUnliftedArray
+  , foldrUnliftedArray'
+  , foldlUnliftedArray
+  , foldlUnliftedArray'
+  , foldlUnliftedArrayM'
+    -- * Traversals
+  , traverseUnliftedArray_
+  , itraverseUnliftedArray_
+    -- * Mapping
+  , mapUnliftedArray
+  ) where
+
+import Control.Monad.ST (ST)
+import Data.Primitive.Unlifted.Class (PrimUnlifted (..))
+import Data.Primitive.Unlifted.Array.Base
+import GHC.Exts (Int(I#),State#)
+import qualified GHC.ST as ST
+
+import qualified Data.List as L
+import qualified GHC.Exts as Exts
+import qualified Data.Primitive.Unlifted.BoxArray.ST as BA
+import Data.Primitive.Unlifted.BoxArray.ST (BoxArray (..), MutableBoxArray (..))
+import Data.Primitive.Unlifted.Box
+
+newtype UnliftedArray a
+  = UnliftedArray (BoxArray (Unlifted a))
+type role UnliftedArray nominal
+
+newtype MutableUnliftedArray s a
+  = MutableUnliftedArray (MutableBoxArray s (Unlifted a))
+type role MutableUnliftedArray nominal nominal
+
+instance PrimUnlifted (UnliftedArray a) where
+  {-# INLINE toUnlifted# #-}
+  {-# INLINE fromUnlifted# #-}
+  type Unlifted (UnliftedArray a) = UnliftedArray# (Unlifted a)
+  toUnlifted# (UnliftedArray (BoxArray ba)) = ba
+  fromUnlifted# x = UnliftedArray (BoxArray x)
+
+instance PrimUnlifted (MutableUnliftedArray s a) where
+  {-# INLINE toUnlifted# #-}
+  {-# INLINE fromUnlifted# #-}
+  type Unlifted (MutableUnliftedArray s a) = MutableUnliftedArray# s (Unlifted a)
+  toUnlifted# (MutableUnliftedArray (MutableBoxArray ba)) = ba
+  fromUnlifted# x = MutableUnliftedArray (MutableBoxArray x)
+
+-- | Creates a new 'MutableUnliftedArray' with the specified value as initial
+-- contents.
+newUnliftedArray
+  :: PrimUnlifted a
+  => Int -- ^ size
+  -> a -- ^ initial value
+  -> ST s (MutableUnliftedArray s a)
+newUnliftedArray len v = MutableUnliftedArray <$> BA.newBoxArray len (toBox v)
+
+setUnliftedArray
+  :: PrimUnlifted a
+  => MutableUnliftedArray s a -- ^ destination
+  -> a -- ^ value to fill with
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s ()
+{-# inline setUnliftedArray #-}
+setUnliftedArray (MutableUnliftedArray mua) v off len = BA.setBoxArray mua (toBox v) off len
+
+-- | Yields the length of an 'UnliftedArray'.
+sizeofUnliftedArray :: UnliftedArray e -> Int
+{-# inline sizeofUnliftedArray #-}
+sizeofUnliftedArray (UnliftedArray ar) = BA.sizeofBoxArray ar
+
+-- | Yields the length of a 'MutableUnliftedArray'.
+sizeofMutableUnliftedArray :: MutableUnliftedArray s e -> Int
+{-# inline sizeofMutableUnliftedArray #-}
+sizeofMutableUnliftedArray (MutableUnliftedArray ma)
+  = BA.sizeofMutableBoxArray ma
+
+{-# SPECIALIZE writeUnliftedArray :: MutableUnliftedArray s (UnliftedArray a) -> Int -> UnliftedArray a -> ST s () #-}
+writeUnliftedArray :: PrimUnlifted a
+  => MutableUnliftedArray s a
+  -> Int
+  -> a
+  -> ST s ()
+{-# inline writeUnliftedArray #-}
+writeUnliftedArray (MutableUnliftedArray arr) ix a = BA.writeBoxArray arr ix (toBox a)
+
+readUnliftedArray :: PrimUnlifted a
+  => MutableUnliftedArray s a
+  -> Int
+  -> ST s a
+{-# inline readUnliftedArray #-}
+readUnliftedArray (MutableUnliftedArray arr) ix = fromBox <$> BA.readBoxArray arr ix
+
+indexUnliftedArray :: PrimUnlifted a
+  => UnliftedArray a
+  -> Int
+  -> a
+{-# inline indexUnliftedArray #-}
+indexUnliftedArray (UnliftedArray arr) ix = fromBox $ BA.indexBoxArray arr ix
+
+-- | Freezes a 'MutableUnliftedArray', yielding an 'UnliftedArray'. This simply
+-- marks the array as frozen in place, so it should only be used when no further
+-- modifications to the mutable array will be performed.
+unsafeFreezeUnliftedArray
+  :: MutableUnliftedArray s a
+  -> ST s (UnliftedArray a)
+unsafeFreezeUnliftedArray (MutableUnliftedArray ma)
+  = UnliftedArray <$> BA.unsafeFreezeBoxArray ma
+{-# inline unsafeFreezeUnliftedArray #-}
+
+-- | Determines whether two 'MutableUnliftedArray' values are the same. This is
+-- object/pointer identity, not based on the contents.
+sameMutableUnliftedArray
+  :: MutableUnliftedArray s a
+  -> MutableUnliftedArray s a
+  -> Bool
+sameMutableUnliftedArray (MutableUnliftedArray ma1) (MutableUnliftedArray ma2)
+  = BA.sameMutableBoxArray ma1 ma2
+{-# inline sameMutableUnliftedArray #-}
+
+-- | Copies the contents of an immutable array into a mutable array.
+copyUnliftedArray
+  :: MutableUnliftedArray s a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> UnliftedArray a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> ST s ()
+{-# inline copyUnliftedArray #-}
+copyUnliftedArray (MutableUnliftedArray dst) doff
+  (UnliftedArray src) soff ln
+  = BA.copyBoxArray dst doff src soff ln
+
+-- | Copies the contents of one mutable array into another.
+copyMutableUnliftedArray
+  :: MutableUnliftedArray s a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> MutableUnliftedArray s a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> ST s ()
+{-# inline copyMutableUnliftedArray #-}
+copyMutableUnliftedArray
+  (MutableUnliftedArray dst) doff
+  (MutableUnliftedArray src) soff ln
+  = BA.copyMutableBoxArray dst doff src soff ln
+
+-- | Freezes a portion of a 'MutableUnliftedArray', yielding an 'UnliftedArray'.
+-- This operation is safe, in that it copies the frozen portion, and the
+-- existing mutable array may still be used afterward.
+freezeUnliftedArray
+  :: MutableUnliftedArray s a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (UnliftedArray a)
+freezeUnliftedArray (MutableUnliftedArray mary) off len =
+  UnliftedArray <$> BA.freezeBoxArray mary off len
+{-# inline freezeUnliftedArray #-}
+
+-- | Thaws a portion of an 'UnliftedArray', yielding a 'MutableUnliftedArray'.
+-- This copies the thawed portion, so mutations will not affect the original
+-- array.
+thawUnliftedArray
+  :: UnliftedArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (MutableUnliftedArray s a)
+{-# inline thawUnliftedArray #-}
+thawUnliftedArray (UnliftedArray ary) off len
+  = MutableUnliftedArray <$> BA.thawBoxArray ary off len
+
+-- | Execute a stateful computation and freeze the resulting array.
+runUnliftedArray
+  :: (forall s. ST s (MutableUnliftedArray s a))
+  -> UnliftedArray a
+{-# INLINE runUnliftedArray #-}
+-- This is what we'd like to write, but GHC does not yet
+-- produce properly unboxed code when we do
+-- runUnliftedArray m = runST $ m >>= unsafeFreezeUnliftedArray
+runUnliftedArray m = UnliftedArray $
+  BA.runBoxArray $ m >>= \(MutableUnliftedArray ma) -> pure ma
+
+-- | Creates a new 'MutableUnliftedArray'. This function is unsafe because it
+-- initializes all elements of the array as pointers to the empty array. Attempting
+-- to read one of these elements before writing to it is in effect an unsafe
+-- coercion from @'UnliftedArray' a@ to the element type.
+unsafeNewUnliftedArray
+  :: Int -- ^ size
+  -> ST s (MutableUnliftedArray s a)
+{-# inline unsafeNewUnliftedArray #-}
+unsafeNewUnliftedArray i = MutableUnliftedArray <$> BA.unsafeNewBoxArray i
+
+-- | Creates a copy of a portion of an 'UnliftedArray'
+cloneUnliftedArray
+  :: UnliftedArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> UnliftedArray a
+{-# inline cloneUnliftedArray #-}
+cloneUnliftedArray (UnliftedArray ary) off len
+  = UnliftedArray (BA.cloneBoxArray ary off len)
+
+-- | Creates a new 'MutableUnliftedArray' containing a copy of a portion of
+-- another mutable array.
+cloneMutableUnliftedArray
+  :: MutableUnliftedArray s a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (MutableUnliftedArray s a)
+{-# inline cloneMutableUnliftedArray #-}
+cloneMutableUnliftedArray (MutableUnliftedArray mary) off len
+  = MutableUnliftedArray <$> BA.cloneMutableBoxArray mary off len
+
+emptyUnliftedArray :: UnliftedArray a
+emptyUnliftedArray = UnliftedArray BA.emptyBoxArray
+
+singletonUnliftedArray :: PrimUnlifted a => a -> UnliftedArray a
+{-# INLINE singletonUnliftedArray #-}
+singletonUnliftedArray x = UnliftedArray $ BA.singletonBoxArray (toBox x)
+
+foldrUnliftedArray :: forall a b. PrimUnlifted a => (a -> b -> b) -> b -> UnliftedArray a -> b
+{-# INLINE foldrUnliftedArray #-}
+foldrUnliftedArray f z (UnliftedArray arr)
+  = BA.foldrBoxArray (\a b -> f (fromBox a) b) z arr
+
+-- | Strict right-associated fold over the elements of an 'UnliftedArray.
+{-# INLINE foldrUnliftedArray' #-}
+foldrUnliftedArray' :: forall a b. PrimUnlifted a => (a -> b -> b) -> b -> UnliftedArray a -> b
+foldrUnliftedArray' f z (UnliftedArray arr)
+  = BA.foldrBoxArray' (\a b -> f (fromBox a) b) z arr
+
+-- | Lazy left-associated fold over the elements of an 'UnliftedArray'.
+{-# INLINE foldlUnliftedArray #-}
+foldlUnliftedArray :: forall a b. PrimUnlifted a => (b -> a -> b) -> b -> UnliftedArray a -> b
+foldlUnliftedArray f z (UnliftedArray arr)
+  = BA.foldlBoxArray (\b a -> f b (fromBox a)) z arr
+
+-- | Strict left-associated fold over the elements of an 'UnliftedArray'.
+{-# INLINE foldlUnliftedArray' #-}
+foldlUnliftedArray' :: forall a b. PrimUnlifted a => (b -> a -> b) -> b -> UnliftedArray a -> b
+foldlUnliftedArray' f z (UnliftedArray arr)
+  = BA.foldlBoxArray' (\b a -> f b (fromBox a)) z arr
+
+-- | Strict effectful left-associated fold over the elements of an 'UnliftedArray'.
+{-# INLINE foldlUnliftedArrayM' #-}
+foldlUnliftedArrayM' :: (PrimUnlifted a, Monad m)
+  => (b -> a -> m b) -> b -> UnliftedArray a -> m b
+foldlUnliftedArrayM' f z (UnliftedArray arr)
+  = BA.foldlBoxArrayM' (\b a -> f b (fromBox a)) z arr
+
+-- | Effectfully traverse the elements of an 'UnliftedArray', discarding
+-- the resulting values.
+{-# INLINE traverseUnliftedArray_ #-}
+traverseUnliftedArray_ :: (PrimUnlifted a, Applicative m)
+  => (a -> m b) -> UnliftedArray a -> m ()
+traverseUnliftedArray_ f (UnliftedArray arr)
+  = BA.traverseBoxArray_ (f . fromBox) arr
+
+-- | Effectful indexed traversal of the elements of an 'UnliftedArray',
+-- discarding the resulting values.
+{-# INLINE itraverseUnliftedArray_ #-}
+itraverseUnliftedArray_ :: (PrimUnlifted a, Applicative m)
+  => (Int -> a -> m b) -> UnliftedArray a -> m ()
+itraverseUnliftedArray_ f (UnliftedArray arr)
+  = BA.itraverseBoxArray_ (\i a -> f i (fromBox a)) arr
+
+-- | Map over the elements of an 'UnliftedArray'.
+{-# INLINE mapUnliftedArray #-}
+mapUnliftedArray :: (PrimUnlifted a, PrimUnlifted b)
+  => (a -> b)
+  -> UnliftedArray a
+  -> UnliftedArray b
+mapUnliftedArray f (UnliftedArray arr) = UnliftedArray $
+  BA.mapBoxArray (toBox . f . fromBox) arr
+
+-- | Convert the unlifted array to a list.
+{-# INLINE unliftedArrayToList #-}
+unliftedArrayToList :: PrimUnlifted a => UnliftedArray a -> [a]
+unliftedArrayToList xs = Exts.build (\c n -> foldrUnliftedArray c n xs)
+
+unliftedArrayFromList :: PrimUnlifted a => [a] -> UnliftedArray a
+{-# INLINE unliftedArrayFromList #-}
+-- We use boxArrayFromListN rather than unliftedArrayFromListN to make the fmap
+-- fuse with the list conversion. Otherwise everything is horrible.
+unliftedArrayFromList xs = UnliftedArray $ BA.boxArrayFromListN (L.length xs) (fmap toBox xs)
+
+unliftedArrayFromListN :: forall a. PrimUnlifted a => Int -> [a] -> UnliftedArray a
+{-# INLINABLE unliftedArrayFromListN #-}
+unliftedArrayFromListN len vs = UnliftedArray $ BA.boxArrayFromListN len (fmap toBox vs)
+
+instance PrimUnlifted a => Exts.IsList (UnliftedArray a) where
+  type Item (UnliftedArray a) = a
+  fromList = unliftedArrayFromList
+  fromListN = unliftedArrayFromListN
+  toList = unliftedArrayToList
+
+instance Semigroup (UnliftedArray a) where
+  {-# INLINE (<>) #-}
+  UnliftedArray a1 <> UnliftedArray a2
+    = UnliftedArray (a1 <> a2)
+
+instance Monoid (UnliftedArray a) where
+  mempty = emptyUnliftedArray
+
+instance (Show a, PrimUnlifted a) => Show (UnliftedArray a) where
+  showsPrec p a = showParen (p > 10) $
+    showString "fromListN " . shows (sizeofUnliftedArray a) . showString " "
+      . shows (unliftedArrayToList a)
+
+instance Eq (MutableUnliftedArray s a) where
+  (==) = sameMutableUnliftedArray
+
+instance (Eq a, PrimUnlifted a) => Eq (UnliftedArray a) where
+  aa1 == aa2 = sizeofUnliftedArray aa1 == sizeofUnliftedArray aa2
+            && loop (sizeofUnliftedArray aa1 - 1)
+   where
+   loop i
+     | i < 0 = True
+     | otherwise = indexUnliftedArray aa1 i == indexUnliftedArray aa2 i && loop (i-1)

--- a/src/Data/Primitive/Unlifted/Box.hs
+++ b/src/Data/Primitive/Unlifted/Box.hs
@@ -6,18 +6,18 @@ module Data.Primitive.Unlifted.Box where
 import GHC.Exts (TYPE, RuntimeRep (UnliftedRep))
 import Data.Primitive.Unlifted.Class
 
-data Box (a :: TYPE 'UnliftedRep) = Box { unBox# :: a }
+data Box (a :: TYPE 'UnliftedRep) = Box# { unBox# :: a }
 
 instance PrimUnlifted (Box a) where
   {-# INLINE toUnlifted# #-}
   {-# INLINE fromUnlifted# #-}
   type Unlifted (Box a) = a
 
-  toUnlifted# (Box a) = a
-  fromUnlifted# a = Box a
+  toUnlifted# (Box# a) = a
+  fromUnlifted# a = Box# a
 
 toBox :: PrimUnlifted a => a -> Box (Unlifted a)
-toBox a = Box (toUnlifted# a)
+toBox a = Box# (toUnlifted# a)
 
 fromBox :: PrimUnlifted a => Box (Unlifted a) -> a
-fromBox (Box a) = fromUnlifted# a
+fromBox (Box# a) = fromUnlifted# a

--- a/src/Data/Primitive/Unlifted/Box.hs
+++ b/src/Data/Primitive/Unlifted/Box.hs
@@ -1,0 +1,23 @@
+{-# language KindSignatures #-}
+{-# language TypeFamilies #-}
+{-# language MagicHash #-}
+
+module Data.Primitive.Unlifted.Box where
+import GHC.Exts (TYPE, RuntimeRep (UnliftedRep))
+import Data.Primitive.Unlifted.Class
+
+data Box (a :: TYPE 'UnliftedRep) = Box { unBox# :: a }
+
+instance PrimUnlifted (Box a) where
+  {-# INLINE toUnlifted# #-}
+  {-# INLINE fromUnlifted# #-}
+  type Unlifted (Box a) = a
+
+  toUnlifted# (Box a) = a
+  fromUnlifted# a = Box a
+
+toBox :: PrimUnlifted a => a -> Box (Unlifted a)
+toBox a = Box (toUnlifted# a)
+
+fromBox :: PrimUnlifted a => Box (Unlifted a) -> a
+fromBox (Box a) = fromUnlifted# a

--- a/src/Data/Primitive/Unlifted/BoxArray.hs
+++ b/src/Data/Primitive/Unlifted/BoxArray.hs
@@ -1,0 +1,496 @@
+{-# language BangPatterns #-}
+{-# language MagicHash #-}
+{-# language RankNTypes #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeFamilies #-}
+{-# language UnboxedTuples #-}
+{-# language RoleAnnotations #-}
+
+-- |
+-- GHC contains three general classes of value types:
+--
+--   1. Unboxed types: values are machine values made up of fixed numbers of bytes
+--   2. Unlifted types: values are pointers, but strictly evaluated
+--   3. Lifted types: values are pointers, lazily evaluated
+--
+-- The first category can be stored in a 'ByteArray', and this allows types in
+-- category 3 that are simple wrappers around category 1 types to be stored
+-- more efficiently using a 'ByteArray'. This module provides the same facility
+-- for category 2 types.
+--
+-- GHC has two primitive types, 'ArrayArray#' and 'MutableArrayArray#'. These
+-- are arrays of pointers, but of category 2 values, so they are known to not
+-- be bottom. This allows types that are wrappers around such types to be stored
+-- in an array without an extra level of indirection.
+--
+-- The way that the 'ArrayArray#' API works is that one can read and write
+-- 'ArrayArray#' values to the positions. This works because all category 2
+-- types share a uniform representation, unlike unboxed values which are
+-- represented by varying (by type) numbers of bytes. However, using the
+-- this makes the internal API very unsafe to use, as one has to coerce values
+-- to and from 'ArrayArray#'.
+--
+-- The API presented by this module is more type safe. 'UnliftedArray' and
+-- 'MutableUnliftedArray' are parameterized by the type of arrays they contain, and
+-- the coercions necessary are abstracted into a class, 'PrimUnlifted', of things
+-- that are eligible to be stored.
+module Data.Primitive.Unlifted.BoxArray
+  ( -- * Types
+    BoxArray(..)
+  , MutableBoxArray(..)
+    -- * Operations
+  , newBoxArray
+  , unsafeNewBoxArray
+  , sizeofBoxArray
+  , sizeofMutableBoxArray
+  , sameMutableBoxArray
+  , writeBoxArray
+  , readBoxArray
+  , indexBoxArray
+  , unsafeFreezeBoxArray
+  , freezeBoxArray
+  , thawBoxArray
+  , setBoxArray
+  , copyBoxArray
+  , copyMutableBoxArray
+  , cloneBoxArray
+  , cloneMutableBoxArray
+  , emptyBoxArray
+  , singletonBoxArray
+  , runBoxArray
+    -- * List Conversion
+  , unliftedArrayToList
+  , unliftedArrayFromList
+  , unliftedArrayFromListN
+    -- * Folding
+  , foldrBoxArray
+  , foldrBoxArray'
+  , foldlBoxArray
+  , foldlBoxArray'
+  , foldlBoxArrayM'
+    -- * Traversals
+  , traverseBoxArray_
+  , itraverseBoxArray_
+    -- * Mapping
+  , mapBoxArray
+  ) where
+
+import Control.Monad.Primitive (PrimMonad,PrimState,primitive,primitive_)
+import Control.Monad.ST (ST)
+import Data.Primitive.Unlifted.Class (PrimUnlifted (..))
+import Data.Primitive.Unlifted.Array.Base
+import Data.Primitive.Unlifted.Box
+import GHC.Exts (Int(I#),State#)
+import qualified GHC.ST as ST
+
+import qualified Data.List as L
+import qualified GHC.Exts as Exts
+
+data BoxArray a
+  = BoxArray (UnliftedArray# a)
+type role BoxArray representational
+
+data MutableBoxArray s a
+  = MutableBoxArray (MutableUnliftedArray# s a)
+type role MutableBoxArray nominal representational
+
+instance PrimUnlifted (BoxArray a) where
+  type Unlifted (BoxArray a) = UnliftedArray# a
+  toUnlifted# (BoxArray a) = a
+  fromUnlifted# x = BoxArray x
+
+instance PrimUnlifted (MutableBoxArray s a) where
+  type Unlifted (MutableBoxArray s a) = MutableUnliftedArray# s a
+  toUnlifted# (MutableBoxArray a) = a
+  fromUnlifted# x = MutableBoxArray x
+
+-- | Creates a new 'MutableBoxArray' with the specified value as initial
+-- contents.
+newBoxArray
+  :: PrimMonad m
+  => Int -- ^ size
+  -> Box a -- ^ initial value
+  -> m (MutableBoxArray (PrimState m) a)
+newBoxArray (I# len) (Box v) = primitive $ \s -> case newUnliftedArray# len v s of
+  (# s', ma #) -> (# s', MutableBoxArray ma #)
+{-# inline newBoxArray #-}
+
+setBoxArray
+  :: PrimMonad m
+  => MutableBoxArray (PrimState m) a -- ^ destination
+  -> Box a -- ^ value to fill with
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> m ()
+{-# inline setBoxArray #-}
+setBoxArray mua v off len = loop (len + off - 1)
+ where
+ loop i
+   | i < off = pure ()
+   | otherwise = writeBoxArray mua i v *> loop (i-1)
+
+-- | Yields the length of an 'BoxArray'.
+sizeofBoxArray :: BoxArray e -> Int
+{-# inline sizeofBoxArray #-}
+sizeofBoxArray (BoxArray ar) = I# (sizeofUnliftedArray# ar)
+
+-- | Yields the length of a 'MutableBoxArray'.
+sizeofMutableBoxArray :: MutableBoxArray s e -> Int
+{-# inline sizeofMutableBoxArray #-}
+sizeofMutableBoxArray (MutableBoxArray maa#)
+  = I# (sizeofMutableUnliftedArray# maa#)
+
+writeBoxArray :: PrimMonad m
+  => MutableBoxArray (PrimState m) a
+  -> Int
+  -> Box a
+  -> m ()
+{-# inline writeBoxArray #-}
+writeBoxArray (MutableBoxArray arr) (I# ix) (Box a) =
+  primitive_ (writeUnliftedArray# arr ix a)
+
+readBoxArray :: PrimMonad m
+  => MutableBoxArray (PrimState m) a
+  -> Int
+  -> m (Box a)
+{-# inline readBoxArray #-}
+readBoxArray (MutableBoxArray arr) (I# ix) =
+  primitive $ \s -> case readUnliftedArray# arr ix s of
+    (# s', a #) -> (# s', Box a #)
+
+indexBoxArray :: BoxArray a
+  -> Int
+  -> Box a
+{-# inline indexBoxArray #-}
+indexBoxArray (BoxArray arr) (I# ix) =
+  Box (indexUnliftedArray# arr ix)
+
+-- | Freezes a 'MutableBoxArray', yielding an 'BoxArray'. This simply
+-- marks the array as frozen in place, so it should only be used when no further
+-- modifications to the mutable array will be performed.
+unsafeFreezeBoxArray
+  :: PrimMonad m
+  => MutableBoxArray (PrimState m) a
+  -> m (BoxArray a)
+unsafeFreezeBoxArray (MutableBoxArray maa#)
+  = primitive $ \s -> case unsafeFreezeUnliftedArray# maa# s of
+      (# s', aa# #) -> (# s', BoxArray aa# #)
+{-# inline unsafeFreezeBoxArray #-}
+
+-- | Determines whether two 'MutableBoxArray' values are the same. This is
+-- object/pointer identity, not based on the contents.
+sameMutableBoxArray
+  :: MutableBoxArray s a
+  -> MutableBoxArray s a
+  -> Bool
+sameMutableBoxArray (MutableBoxArray maa1#) (MutableBoxArray maa2#)
+  = Exts.isTrue# (sameMutableUnliftedArray# maa1# maa2#)
+{-# inline sameMutableBoxArray #-}
+
+-- | Copies the contents of an immutable array into a mutable array.
+copyBoxArray
+  :: (PrimMonad m)
+  => MutableBoxArray (PrimState m) a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> BoxArray a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> m ()
+{-# inline copyBoxArray #-}
+copyBoxArray
+  (MutableBoxArray dst) (I# doff)
+  (BoxArray src) (I# soff) (I# ln) =
+    primitive_ $ copyUnliftedArray# src soff dst doff ln
+
+-- | Copies the contents of one mutable array into another.
+copyMutableBoxArray
+  :: (PrimMonad m)
+  => MutableBoxArray (PrimState m) a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> MutableBoxArray (PrimState m) a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> m ()
+{-# inline copyMutableBoxArray #-}
+copyMutableBoxArray
+  (MutableBoxArray dst) (I# doff)
+  (MutableBoxArray src) (I# soff) (I# ln) =
+    primitive_ $ copyMutableUnliftedArray# src soff dst doff ln
+
+-- | Freezes a portion of a 'MutableBoxArray', yielding an 'BoxArray'.
+-- This operation is safe, in that it copies the frozen portion, and the
+-- existing mutable array may still be used afterward.
+freezeBoxArray
+  :: (PrimMonad m)
+  => MutableBoxArray (PrimState m) a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> m (BoxArray a)
+freezeBoxArray (MutableBoxArray mary) (I# off) (I# len) =
+    primitive $ \s -> case freezeUnliftedArray# mary off len s of
+      (# s', ary #) -> (# s', BoxArray ary #)
+{-# inline freezeBoxArray #-}
+
+-- | Thaws a portion of an 'BoxArray', yielding a 'MutableBoxArray'.
+-- This copies the thawed portion, so mutations will not affect the original
+-- array.
+thawBoxArray
+  :: (PrimMonad m)
+  => BoxArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> m (MutableBoxArray (PrimState m) a)
+{-# inline thawBoxArray #-}
+thawBoxArray (BoxArray ary) (I# off) (I# len) =
+    primitive $ \s -> case thawUnliftedArray# ary off len s of
+      (# s', mary #) -> (# s', MutableBoxArray mary #)
+
+-- | Execute a stateful computation and freeze the resulting array.
+runBoxArray
+  :: (forall s. ST s (MutableBoxArray s a))
+  -> BoxArray a
+{-# INLINE runBoxArray #-}
+-- This is what we'd like to write, but GHC does not yet
+-- produce properly unboxed code when we do
+-- runBoxArray m = runST $ m >>= unsafeFreezeBoxArray
+runBoxArray m = BoxArray (runUnliftedArray# m)
+
+runUnliftedArray#
+  :: (forall s. ST s (MutableBoxArray s a))
+  -> UnliftedArray# a
+runUnliftedArray# m = case Exts.runRW# $ \s ->
+  case unST m s of { (# s', MutableBoxArray mary# #) ->
+  unsafeFreezeUnliftedArray# mary# s'} of (# _, ary# #) -> ary#
+{-# INLINE runUnliftedArray# #-}
+
+unST :: ST s a -> State# s -> (# State# s, a #)
+unST (ST.ST f) = f
+
+unsafeCreateBoxArray
+  :: Int
+  -> (forall s. MutableBoxArray s a -> ST s ())
+  -> BoxArray a
+unsafeCreateBoxArray !n f = runBoxArray $ do
+  mary <- unsafeNewBoxArray n
+  f mary
+  pure mary
+
+-- | Creates a new 'MutableBoxArray'. This function is unsafe because it
+-- initializes all elements of the array as pointers to the empty array. Attempting
+-- to read one of these elements before writing to it is in effect an unsafe
+-- coercion from @'BoxArray' a@ to the element type.
+unsafeNewBoxArray
+  :: (PrimMonad m)
+  => Int -- ^ size
+  -> m (MutableBoxArray (PrimState m) a)
+{-# inline unsafeNewBoxArray #-}
+unsafeNewBoxArray (I# i) = primitive $ \s -> case unsafeNewUnliftedArray# i s of
+  (# s', ma #) -> (# s', MutableBoxArray ma #)
+
+
+-- | Creates a copy of a portion of an 'BoxArray'
+cloneBoxArray
+  :: BoxArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> BoxArray a
+{-# inline cloneBoxArray #-}
+cloneBoxArray (BoxArray ary) (I# off) (I# len)
+  = BoxArray (cloneUnliftedArray# ary off len)
+
+-- | Creates a new 'MutableBoxArray' containing a copy of a portion of
+-- another mutable array.
+cloneMutableBoxArray
+  :: (PrimMonad m)
+  => MutableBoxArray (PrimState m) a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> m (MutableBoxArray (PrimState m) a)
+{-# inline cloneMutableBoxArray #-}
+cloneMutableBoxArray (MutableBoxArray mary) (I# off) (I# len)
+  = primitive $ \s -> case cloneMutableUnliftedArray# mary off len s of
+      (# s', mary' #) -> (# s', MutableBoxArray mary' #)
+
+emptyBoxArray :: BoxArray a
+emptyBoxArray = BoxArray (emptyUnliftedArray# Exts.void#)
+
+singletonBoxArray :: Box a -> BoxArray a
+{-# INLINE singletonBoxArray #-}
+singletonBoxArray x = runBoxArray $ newBoxArray 1 x
+
+concatBoxArray :: BoxArray a -> BoxArray a -> BoxArray a
+{-# INLINE concatBoxArray #-}
+concatBoxArray (BoxArray a1) (BoxArray a2)
+  = BoxArray (concatUnliftedArray# a1 a2)
+
+-- This junk is to make sure we unbox properly. Inlining this doesn't seem
+-- likely to be much of a win ever, and could potentially lead to reboxing,
+-- so we NOINLINE. It would be nice to find a prettier way to do this.
+concatUnliftedArray# :: UnliftedArray# a -> UnliftedArray# a -> UnliftedArray# a
+{-# NOINLINE concatUnliftedArray# #-}
+concatUnliftedArray# a1 a2 =
+  let !sza1 = sizeofUnliftedArray# a1
+  in
+    if Exts.isTrue# (sza1 Exts.==# 0#)
+    then a2
+    else
+      let !sza2 = sizeofUnliftedArray# a2
+      in
+        if Exts.isTrue# (sza2 Exts.==# 0#)
+        then a1
+        else Exts.runRW# $ \s ->
+          case unsafeNewUnliftedArray# (sza1 Exts.+# sza2) s of { (# s', ma #) ->
+          case copyUnliftedArray# a1 0# ma 0# sza1 s' of { s'' ->
+          case copyUnliftedArray# a2 0# ma sza1 sza2 s'' of { s''' ->
+          case unsafeFreezeUnliftedArray# ma s''' of
+            (# _, ar #) -> ar}}}
+
+foldrBoxArray :: forall a b. (Box a -> b -> b) -> b -> BoxArray a -> b
+{-# INLINE foldrBoxArray #-}
+foldrBoxArray f z arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | sz > i = f (indexBoxArray arr i) (go (i+1))
+      | otherwise = z
+
+-- | Strict right-associated fold over the elements of an 'BoxArray.
+{-# INLINE foldrBoxArray' #-}
+foldrBoxArray' :: forall a b. (Box a -> b -> b) -> b -> BoxArray a -> b
+foldrBoxArray' f z0 arr = go (sizeofBoxArray arr - 1) z0
+  where
+    go !i !acc
+      | i < 0 = acc
+      | otherwise = go (i - 1) (f (indexBoxArray arr i) acc)
+
+-- | Lazy left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArray #-}
+foldlBoxArray :: forall a b. (b -> Box a -> b) -> b -> BoxArray a -> b
+foldlBoxArray f z arr = go (sizeofBoxArray arr - 1)
+  where
+    go !i
+      | i < 0 = z
+      | otherwise = f (go (i - 1)) (indexBoxArray arr i)
+
+-- | Strict left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArray' #-}
+foldlBoxArray' :: forall a b. (b -> Box a -> b) -> b -> BoxArray a -> b
+foldlBoxArray' f z0 arr = go 0 z0
+  where
+    !sz = sizeofBoxArray arr
+    go !i !acc
+      | i < sz = go (i + 1) (f acc (indexBoxArray arr i))
+      | otherwise = acc
+
+-- | Strict effectful left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArrayM' #-}
+foldlBoxArrayM' :: Monad m
+  => (b -> Box a -> m b) -> b -> BoxArray a -> m b
+foldlBoxArrayM' f z0 arr = go 0 z0
+  where
+    !sz = sizeofBoxArray arr
+    go !i !acc
+      | i < sz = f acc (indexBoxArray arr i) >>= go (i + 1) 
+      | otherwise = pure acc
+
+-- | Effectfully traverse the elements of an 'BoxArray', discarding
+-- the resulting values.
+{-# INLINE traverseBoxArray_ #-}
+traverseBoxArray_ :: Applicative m
+  => (Box a -> m b) -> BoxArray a -> m ()
+traverseBoxArray_ f arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | i < sz = f (indexBoxArray arr i) *> go (i + 1) 
+      | otherwise = pure ()
+
+-- | Effectful indexed traversal of the elements of an 'BoxArray',
+-- discarding the resulting values.
+{-# INLINE itraverseBoxArray_ #-}
+itraverseBoxArray_ :: Applicative m
+  => (Int -> Box a -> m b) -> BoxArray a -> m ()
+itraverseBoxArray_ f arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | i < sz = f i (indexBoxArray arr i) *> go (i + 1) 
+      | otherwise = pure ()
+
+-- | Map over the elements of an 'BoxArray'.
+{-# INLINE mapBoxArray #-}
+mapBoxArray ::
+     (Box a -> Box b)
+  -> BoxArray a
+  -> BoxArray b
+mapBoxArray f arr = unsafeCreateBoxArray sz $ \marr -> do
+  let go !ix = if ix < sz
+        then do
+          let b = f (indexBoxArray arr ix)
+          writeBoxArray marr ix b
+          go (ix + 1)
+        else return ()
+  go 0
+  where
+  !sz = sizeofBoxArray arr
+
+-- | Convert the unlifted array to a list.
+{-# INLINE unliftedArrayToList #-}
+unliftedArrayToList :: BoxArray a -> [Box a]
+unliftedArrayToList xs = Exts.build (\c n -> foldrBoxArray c n xs)
+
+unliftedArrayFromList :: [Box a] -> BoxArray a
+unliftedArrayFromList xs = unliftedArrayFromListN (L.length xs) xs
+
+unliftedArrayFromListN :: forall a. Int -> [Box a] -> BoxArray a
+unliftedArrayFromListN len vs = unsafeCreateBoxArray len run where
+  run :: forall s. MutableBoxArray s a -> ST s ()
+  run arr = do
+    let go :: [Box a] -> Int -> ST s ()
+        go [] !ix = if ix == len
+          -- The size check is mandatory since failure to initialize all elements
+          -- introduces the possibility of a segfault happening when someone attempts
+          -- to read the unitialized element. See the docs for unsafeNewBoxArray.
+          then return ()
+          else die "unliftedArrayFromListN" "list length less than specified size"
+        go (a : as) !ix = if ix < len
+          then do
+            writeBoxArray arr ix a
+            go as (ix + 1)
+          else die "unliftedArrayFromListN" "list length greater than specified size"
+    go vs 0
+
+instance Exts.IsList (BoxArray a) where
+  type Item (BoxArray a) = Box a
+  fromList = unliftedArrayFromList
+  fromListN = unliftedArrayFromListN
+  toList = unliftedArrayToList
+
+instance Semigroup (BoxArray a) where
+  (<>) = concatBoxArray
+
+instance Monoid (BoxArray a) where
+  mempty = emptyBoxArray
+
+instance Eq (MutableBoxArray s a) where
+  (==) = sameMutableBoxArray
+
+die :: String -> String -> a
+die fun problem = error $ "Data.Primitive.Unlifted.BoxArray." ++ fun ++ ": " ++ problem
+
+{-
+-- TODO: Work out Show, Eq, and Ord instances for appropriate types.
+
+instance (Show a, ???) => Show (BoxArray a) where
+  showsPrec p a = showParen (p > 10) $
+    showString "fromListN " . shows (sizeofBoxArray a) . showString " "
+      . shows (unliftedArrayToList a)
+
+instance ??? => Eq (BoxArray a) where
+  aa1 == aa2 = sizeofBoxArray aa1 == sizeofBoxArray aa2
+            && loop (sizeofBoxArray aa1 - 1)
+   where
+   loop i
+     | i < 0 = True
+     | otherwise = indexBoxArray aa1 i == indexBoxArray aa2 i && loop (i-1)
+-}

--- a/src/Data/Primitive/Unlifted/BoxArray/ST.hs
+++ b/src/Data/Primitive/Unlifted/BoxArray/ST.hs
@@ -1,0 +1,506 @@
+{-# language BangPatterns #-}
+{-# language MagicHash #-}
+{-# language RankNTypes #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeFamilies #-}
+{-# language UnboxedTuples #-}
+{-# language RoleAnnotations #-}
+{- OPTIONS_GHC -ddump-simpl #-}
+
+-- |
+-- GHC contains three general classes of value types:
+--
+--   1. Unboxed types: values are machine values made up of fixed numbers of bytes
+--   2. Unlifted types: values are pointers, but strictly evaluated
+--   3. Lifted types: values are pointers, lazily evaluated
+--
+-- The first category can be stored in a 'ByteArray', and this allows types in
+-- category 3 that are simple wrappers around category 1 types to be stored
+-- more efficiently using a 'ByteArray'. This module provides the same facility
+-- for category 2 types.
+--
+-- GHC has two primitive types, 'ArrayArray#' and 'MutableArrayArray#'. These
+-- are arrays of pointers, but of category 2 values, so they are known to not
+-- be bottom. This allows types that are wrappers around such types to be stored
+-- in an array without an extra level of indirection.
+--
+-- The way that the 'ArrayArray#' API works is that one can read and write
+-- 'ArrayArray#' values to the positions. This works because all category 2
+-- types share a uniform representation, unlike unboxed values which are
+-- represented by varying (by type) numbers of bytes. However, using the
+-- this makes the internal API very unsafe to use, as one has to coerce values
+-- to and from 'ArrayArray#'.
+--
+-- The API presented by this module is more type safe. 'UnliftedArray' and
+-- 'MutableUnliftedArray' are parameterized by the type of arrays they contain, and
+-- the coercions necessary are abstracted into a class, 'PrimUnlifted', of things
+-- that are eligible to be stored.
+module Data.Primitive.Unlifted.BoxArray.ST
+  ( -- * Types
+    BoxArray(..)
+  , MutableBoxArray(..)
+    -- * Operations
+  , newBoxArray
+  , unsafeNewBoxArray
+  , sizeofBoxArray
+  , sizeofMutableBoxArray
+  , sameMutableBoxArray
+  , writeBoxArray
+  , readBoxArray
+  , indexBoxArray
+  , unsafeFreezeBoxArray
+  , freezeBoxArray
+  , thawBoxArray
+  , setBoxArray
+  , copyBoxArray
+  , copyMutableBoxArray
+  , cloneBoxArray
+  , cloneMutableBoxArray
+  , emptyBoxArray
+  , singletonBoxArray
+  , runBoxArray
+    -- * List Conversion
+  , boxArrayToList
+  , boxArrayFromList
+  , boxArrayFromListN
+    -- * Folding
+  , foldrBoxArray
+  , foldrBoxArray'
+  , foldlBoxArray
+  , foldlBoxArray'
+  , foldlBoxArrayM'
+    -- * Traversals
+  , traverseBoxArray_
+  , itraverseBoxArray_
+    -- * Mapping
+  , mapBoxArray
+  ) where
+
+--import Control.Monad.Primitive (primitive,primitive_)
+import Data.Primitive.Unlifted.Class (PrimUnlifted (..))
+import Data.Primitive.Unlifted.Array.Base
+import Data.Primitive.Unlifted.Box (Box (..))
+import GHC.Exts (Int(I#),State#)
+import GHC.ST as ST (ST (..))
+
+import qualified Data.List as L
+import qualified GHC.Exts as Exts
+
+-- We copy these from Control.Monad.Primitive purely to make
+-- the Core easier to read. Using these knocks out the PrimState-related
+-- coercions.
+primitive :: (State# s -> (# State# s, a #)) -> ST s a
+primitive m = ST m
+{-# INLINE primitive #-}
+
+primitive_ :: (State# s -> State# s) -> ST s ()
+primitive_ m = ST (\s -> (# m s, () #))
+{-# INLINE primitive_ #-}
+
+data BoxArray a
+  = BoxArray (UnliftedArray# a)
+type role BoxArray representational
+
+data MutableBoxArray s a
+  = MutableBoxArray (MutableUnliftedArray# s a)
+type role MutableBoxArray nominal representational
+
+instance PrimUnlifted (BoxArray a) where
+  type Unlifted (BoxArray a) = UnliftedArray# a
+  toUnlifted# (BoxArray a) = a
+  fromUnlifted# x = BoxArray x
+
+instance PrimUnlifted (MutableBoxArray s a) where
+  type Unlifted (MutableBoxArray s a) = MutableUnliftedArray# s a
+  toUnlifted# (MutableBoxArray a) = a
+  fromUnlifted# x = MutableBoxArray x
+
+-- | Creates a new 'MutableBoxArray' with the specified value as initial
+-- contents.
+newBoxArray
+  :: Int -- ^ size
+  -> Box a -- ^ initial value
+  -> ST s (MutableBoxArray s a)
+newBoxArray (I# len) (Box# v) = primitive $ \s -> case newUnliftedArray# len v s of
+  (# s', ma #) -> (# s', MutableBoxArray ma #)
+{-# inline newBoxArray #-}
+
+setBoxArray
+  :: MutableBoxArray s a -- ^ destination
+  -> Box a -- ^ value to fill with
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s ()
+{-# inline setBoxArray #-}
+setBoxArray !mua !v off len = loop (len + off - 1)
+ where
+ loop i
+   | i < off = pure ()
+   | otherwise = writeBoxArray mua i v *> loop (i-1)
+
+-- | Yields the length of an 'BoxArray'.
+sizeofBoxArray :: BoxArray e -> Int
+{-# inline sizeofBoxArray #-}
+sizeofBoxArray (BoxArray ar) = I# (sizeofUnliftedArray# ar)
+
+-- | Yields the length of a 'MutableBoxArray'.
+sizeofMutableBoxArray :: MutableBoxArray s e -> Int
+{-# inline sizeofMutableBoxArray #-}
+sizeofMutableBoxArray (MutableBoxArray maa#)
+  = I# (sizeofMutableUnliftedArray# maa#)
+
+writeBoxArray ::
+     MutableBoxArray s a
+  -> Int
+  -> Box a
+  -> ST s ()
+{-# inline writeBoxArray #-}
+writeBoxArray (MutableBoxArray arr) (I# ix) (Box# a) =
+  primitive_ (writeUnliftedArray# arr ix a)
+
+readBoxArray ::
+     MutableBoxArray s a
+  -> Int
+  -> ST s (Box a)
+{-# inline readBoxArray #-}
+readBoxArray (MutableBoxArray arr) (I# ix) =
+  primitive $ \s -> case readUnliftedArray# arr ix s of
+    (# s', a #) -> (# s', Box# a #)
+
+indexBoxArray :: BoxArray a
+  -> Int
+  -> Box a
+{-# inline indexBoxArray #-}
+indexBoxArray (BoxArray arr) (I# ix) =
+  Box# (indexUnliftedArray# arr ix)
+
+-- | Freezes a 'MutableBoxArray', yielding an 'BoxArray'. This simply
+-- marks the array as frozen in place, so it should only be used when no further
+-- modifications to the mutable array will be performed.
+unsafeFreezeBoxArray
+  :: MutableBoxArray s a
+  -> ST s (BoxArray a)
+unsafeFreezeBoxArray (MutableBoxArray maa#)
+  = primitive $ \s -> case unsafeFreezeUnliftedArray# maa# s of
+      (# s', aa# #) -> (# s', BoxArray aa# #)
+{-# inline unsafeFreezeBoxArray #-}
+
+-- | Determines whether two 'MutableBoxArray' values are the same. This is
+-- object/pointer identity, not based on the contents.
+sameMutableBoxArray
+  :: MutableBoxArray s a
+  -> MutableBoxArray s a
+  -> Bool
+sameMutableBoxArray (MutableBoxArray maa1#) (MutableBoxArray maa2#)
+  = Exts.isTrue# (sameMutableUnliftedArray# maa1# maa2#)
+{-# inline sameMutableBoxArray #-}
+
+-- | Copies the contents of an immutable array into a mutable array.
+copyBoxArray
+  :: MutableBoxArray s a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> BoxArray a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> ST s ()
+{-# inline copyBoxArray #-}
+copyBoxArray
+  (MutableBoxArray dst) (I# doff)
+  (BoxArray src) (I# soff) (I# ln) =
+    primitive_ $ copyUnliftedArray# src soff dst doff ln
+
+-- | Copies the contents of one mutable array into another.
+copyMutableBoxArray
+  :: MutableBoxArray s a -- ^ destination
+  -> Int -- ^ offset into destination
+  -> MutableBoxArray s a -- ^ source
+  -> Int -- ^ offset into source
+  -> Int -- ^ number of elements to copy
+  -> ST s ()
+{-# inline copyMutableBoxArray #-}
+copyMutableBoxArray
+  (MutableBoxArray dst) (I# doff)
+  (MutableBoxArray src) (I# soff) (I# ln) =
+    primitive_ $ copyMutableUnliftedArray# src soff dst doff ln
+
+-- | Freezes a portion of a 'MutableBoxArray', yielding an 'BoxArray'.
+-- This operation is safe, in that it copies the frozen portion, and the
+-- existing mutable array may still be used afterward.
+freezeBoxArray
+  :: MutableBoxArray s a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (BoxArray a)
+freezeBoxArray (MutableBoxArray mary) (I# off) (I# len) =
+    primitive $ \s -> case freezeUnliftedArray# mary off len s of
+      (# s', ary #) -> (# s', BoxArray ary #)
+{-# inline freezeBoxArray #-}
+
+-- | Thaws a portion of an 'BoxArray', yielding a 'MutableBoxArray'.
+-- This copies the thawed portion, so mutations will not affect the original
+-- array.
+thawBoxArray
+  :: BoxArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (MutableBoxArray s a)
+{-# inline thawBoxArray #-}
+thawBoxArray (BoxArray ary) (I# off) (I# len) =
+    primitive $ \s -> case thawUnliftedArray# ary off len s of
+      (# s', mary #) -> (# s', MutableBoxArray mary #)
+
+-- | Execute a stateful computation and freeze the resulting array.
+runBoxArray
+  :: (forall s. ST s (MutableBoxArray s a))
+  -> BoxArray a
+{-# INLINE runBoxArray #-}
+-- This is what we'd like to write, but GHC does not yet
+-- produce properly unboxed code when we do
+-- runBoxArray m = runST $ m >>= unsafeFreezeBoxArray
+runBoxArray m = BoxArray (runUnliftedArray# m)
+
+runUnliftedArray#
+  :: (forall s. ST s (MutableBoxArray s a))
+  -> UnliftedArray# a
+runUnliftedArray# m = case Exts.runRW# $ \s ->
+  case unST m s of { (# s', MutableBoxArray mary# #) ->
+  unsafeFreezeUnliftedArray# mary# s'} of (# _, ary# #) -> ary#
+{-# INLINE runUnliftedArray# #-}
+
+unST :: ST s a -> State# s -> (# State# s, a #)
+unST (ST.ST f) = f
+
+unsafeCreateBoxArray
+  :: Int
+  -> (forall s. MutableBoxArray s a -> ST s ())
+  -> BoxArray a
+unsafeCreateBoxArray !n f = runBoxArray $ do
+  mary <- unsafeNewBoxArray n
+  f mary
+  pure mary
+
+-- | Creates a new 'MutableBoxArray'. This function is unsafe because it
+-- initializes all elements of the array as pointers to the empty array. Attempting
+-- to read one of these elements before writing to it is in effect an unsafe
+-- coercion from @'BoxArray' a@ to the element type.
+unsafeNewBoxArray
+  :: Int -- ^ size
+  -> ST s (MutableBoxArray s a)
+{-# inline unsafeNewBoxArray #-}
+unsafeNewBoxArray (I# i) = primitive $ \s -> case unsafeNewUnliftedArray# i s of
+  (# s', ma #) -> (# s', MutableBoxArray ma #)
+
+
+-- | Creates a copy of a portion of an 'BoxArray'
+cloneBoxArray
+  :: BoxArray a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> BoxArray a
+{-# inline cloneBoxArray #-}
+cloneBoxArray (BoxArray ary) (I# off) (I# len)
+  = BoxArray (cloneUnliftedArray# ary off len)
+
+-- | Creates a new 'MutableBoxArray' containing a copy of a portion of
+-- another mutable array.
+cloneMutableBoxArray
+  :: MutableBoxArray s a -- ^ source
+  -> Int -- ^ offset
+  -> Int -- ^ length
+  -> ST s (MutableBoxArray s a)
+{-# inline cloneMutableBoxArray #-}
+cloneMutableBoxArray (MutableBoxArray mary) (I# off) (I# len)
+  = primitive $ \s -> case cloneMutableUnliftedArray# mary off len s of
+      (# s', mary' #) -> (# s', MutableBoxArray mary' #)
+
+emptyBoxArray :: BoxArray a
+emptyBoxArray = BoxArray (emptyUnliftedArray# Exts.void#)
+
+singletonBoxArray :: Box a -> BoxArray a
+{-# INLINE singletonBoxArray #-}
+singletonBoxArray x = runBoxArray $ newBoxArray 1 x
+
+concatBoxArray :: BoxArray a -> BoxArray a -> BoxArray a
+{-# INLINE concatBoxArray #-}
+concatBoxArray (BoxArray a1) (BoxArray a2)
+  = BoxArray (concatUnliftedArray# a1 a2)
+
+-- This junk is to make sure we unbox properly. Inlining this doesn't seem
+-- likely to be much of a win ever, and could potentially lead to reboxing,
+-- so we NOINLINE. It would be nice to find a prettier way to do this.
+concatUnliftedArray# :: UnliftedArray# a -> UnliftedArray# a -> UnliftedArray# a
+{-# NOINLINE concatUnliftedArray# #-}
+concatUnliftedArray# a1 a2 =
+  let !sza1 = sizeofUnliftedArray# a1
+  in
+    if Exts.isTrue# (sza1 Exts.==# 0#)
+    then a2
+    else
+      let !sza2 = sizeofUnliftedArray# a2
+      in
+        if Exts.isTrue# (sza2 Exts.==# 0#)
+        then a1
+        else Exts.runRW# $ \s ->
+          case unsafeNewUnliftedArray# (sza1 Exts.+# sza2) s of { (# s', ma #) ->
+          case copyUnliftedArray# a1 0# ma 0# sza1 s' of { s'' ->
+          case copyUnliftedArray# a2 0# ma sza1 sza2 s'' of { s''' ->
+          case unsafeFreezeUnliftedArray# ma s''' of
+            (# _, ar #) -> ar}}}
+
+foldrBoxArray :: forall a b. (Box a -> b -> b) -> b -> BoxArray a -> b
+{-# INLINE foldrBoxArray #-}
+foldrBoxArray f z arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | sz > i = f (indexBoxArray arr i) (go (i+1))
+      | otherwise = z
+
+-- | Strict right-associated fold over the elements of an 'BoxArray.
+{-# INLINE foldrBoxArray' #-}
+foldrBoxArray' :: forall a b. (Box a -> b -> b) -> b -> BoxArray a -> b
+foldrBoxArray' f z0 arr = go (sizeofBoxArray arr - 1) z0
+  where
+    go !i !acc
+      | i < 0 = acc
+      | otherwise = go (i - 1) (f (indexBoxArray arr i) acc)
+
+-- | Lazy left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArray #-}
+foldlBoxArray :: forall a b. (b -> Box a -> b) -> b -> BoxArray a -> b
+foldlBoxArray f z arr = go (sizeofBoxArray arr - 1)
+  where
+    go !i
+      | i < 0 = z
+      | otherwise = f (go (i - 1)) (indexBoxArray arr i)
+
+-- | Strict left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArray' #-}
+foldlBoxArray' :: forall a b. (b -> Box a -> b) -> b -> BoxArray a -> b
+foldlBoxArray' f z0 arr = go 0 z0
+  where
+    !sz = sizeofBoxArray arr
+    go !i !acc
+      | i < sz = go (i + 1) (f acc (indexBoxArray arr i))
+      | otherwise = acc
+
+-- | Strict effectful left-associated fold over the elements of an 'BoxArray'.
+{-# INLINE foldlBoxArrayM' #-}
+foldlBoxArrayM' :: Monad m
+  => (b -> Box a -> m b) -> b -> BoxArray a -> m b
+foldlBoxArrayM' f z0 arr = go 0 z0
+  where
+    !sz = sizeofBoxArray arr
+    go !i !acc
+      | i < sz = f acc (indexBoxArray arr i) >>= go (i + 1) 
+      | otherwise = pure acc
+
+-- | Effectfully traverse the elements of an 'BoxArray', discarding
+-- the resulting values.
+{-# INLINE traverseBoxArray_ #-}
+traverseBoxArray_ :: Applicative m
+  => (Box a -> m b) -> BoxArray a -> m ()
+traverseBoxArray_ f arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | i < sz = f (indexBoxArray arr i) *> go (i + 1) 
+      | otherwise = pure ()
+
+-- | Effectful indexed traversal of the elements of an 'BoxArray',
+-- discarding the resulting values.
+{-# INLINE itraverseBoxArray_ #-}
+itraverseBoxArray_ :: Applicative m
+  => (Int -> Box a -> m b) -> BoxArray a -> m ()
+itraverseBoxArray_ f arr = go 0
+  where
+    !sz = sizeofBoxArray arr
+    go !i
+      | i < sz = f i (indexBoxArray arr i) *> go (i + 1) 
+      | otherwise = pure ()
+
+-- | Map over the elements of an 'BoxArray'.
+{-# INLINE mapBoxArray #-}
+mapBoxArray ::
+     (Box a -> Box b)
+  -> BoxArray a
+  -> BoxArray b
+mapBoxArray f arr = unsafeCreateBoxArray sz $ \marr -> do
+  let go !ix = if ix < sz
+        then do
+          let b = f (indexBoxArray arr ix)
+          writeBoxArray marr ix b
+          go (ix + 1)
+        else return ()
+  go 0
+  where
+  !sz = sizeofBoxArray arr
+
+-- | Convert the unlifted array to a list.
+{-# INLINE boxArrayToList #-}
+boxArrayToList :: BoxArray a -> [Box a]
+boxArrayToList xs = Exts.build (\c n -> foldrBoxArray c n xs)
+
+boxArrayFromList :: [Box a] -> BoxArray a
+boxArrayFromList xs = boxArrayFromListN (L.length xs) xs
+
+boxArrayFromListN :: forall a. Int -> [Box a] -> BoxArray a
+{-# INLINE boxArrayFromListN #-}
+boxArrayFromListN len vs = unsafeCreateBoxArray len run where
+  run :: forall s. MutableBoxArray s a -> ST s ()
+  run arr = foldr go stop vs 0
+    where
+      go !a r ix
+        | ix < len
+        = writeBoxArray arr ix a *> r (ix + 1)
+        | otherwise
+        = boxArrayTooLong
+      stop ix
+        -- The size check is mandatory since failure to initialize all elements
+        -- introduces the possibility of a segfault happening when someone attempts
+        -- to read the unitialized element. See the docs for unsafeNewBoxArray.
+        | ix == len
+        = pure ()
+        | otherwise
+        = boxArrayTooShort
+
+boxArrayTooLong :: ST s ()
+boxArrayTooLong = die "boxArrayFromListN" "list length greater than specified size"
+
+boxArrayTooShort :: ST s ()
+boxArrayTooShort = die "boxArrayFromListN" "list length less than specified size"
+
+instance Exts.IsList (BoxArray a) where
+  type Item (BoxArray a) = Box a
+  fromList = boxArrayFromList
+  fromListN = boxArrayFromListN
+  toList = boxArrayToList
+
+instance Semigroup (BoxArray a) where
+  (<>) = concatBoxArray
+
+instance Monoid (BoxArray a) where
+  mempty = emptyBoxArray
+
+instance Eq (MutableBoxArray s a) where
+  (==) = sameMutableBoxArray
+
+die :: String -> String -> a
+die fun problem = error $ "Data.Primitive.Unlifted.BoxArray." ++ fun ++ ": " ++ problem
+
+{-
+-- TODO: Work out Show, Eq, and Ord instances for appropriate types.
+
+instance (Show a, ???) => Show (BoxArray a) where
+  showsPrec p a = showParen (p > 10) $
+    showString "fromListN " . shows (sizeofBoxArray a) . showString " "
+      . shows (unliftedArrayToList a)
+
+instance ??? => Eq (BoxArray a) where
+  aa1 == aa2 = sizeofBoxArray aa1 == sizeofBoxArray aa2
+            && loop (sizeofBoxArray aa1 - 1)
+   where
+   loop i
+     | i < 0 = True
+     | otherwise = indexBoxArray aa1 i == indexBoxArray aa2 i && loop (i-1)
+-}


### PR DESCRIPTION
* Use `Array# Any` instead of `ArrayArray#` to represent unlifted
  arrays. That gives us access to a lot more primitive operations. Now
  that the FFI crud has been fixed, *hopefully* this won't lead to any
  safety issues.
* Use an unlifted newtype (thanks, Andrew!) to express a "primitive"
  `UnliftedArray#` interface.
* Add `PrimUnlifted` instances for `MutVar`, `TVar`, and `Weak`.
* Remove almost all the methods from the `PrimUnlifted` class,
  making them functions.