### PR TITLE
Make things safer

### DIFF
--- a/UnsafeCoercions.md
+++ b/UnsafeCoercions.md
@@ -2,133 +2,50 @@ This package offers operations on *unlifted* datatypes using GHC primitives
 intended for working with *lifted* datatypes. This requires fairly liberal use
 of `unsafeCoerce#`, which is always a bit tricky to use safely. One
 particularly tricky aspect has to do with extracting values from primop
-results. For example, one might imagine implementing `readUnliftedArray#` like
+results. For example, one might imagine implementing `readSmallUnliftedArray#` like
 so:
 
 ```haskell
-readUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> State# s -> (# State# s, a #)
-readUnliftedArray# (MutableUnliftedArray# mary) i s
-  = case Exts.readArray# mary i s of
+readSmallUnliftedArray# :: SmallMutableUnliftedArray# s a -> Int# -> State# s -> (# State# s, a #)
+readSmallUnliftedArray# (SmallMutableUnliftedArray# mary) i s
+  = case Exts.readSmallArray# mary i s of
       (# s', a #) -> (# s', unsafeCoerce# a #)
 ```
 
-Now we define
+Unfortunately, GHC is *really* not designed to support unsafe coercions between
+lifted and unlifted types. One thing that can happen is that `unsafeCoerce#`
+can be floated around `case` in various ways. Since Core `case` with a *lifted*
+scrutinee will *force* (specifically, *enter*) that scrutinee, things go very
+wrong. The above code would actually end up being compiled to something like
 
 ```haskell
-readUnliftedArray :: PrimUnlifted a
-  => MutableUnliftedArray s a
-  -> Int
-  -> ST s a
-{-# inline readUnliftedArray #-}
-readUnliftedArray (MutableUnliftedArray arr) (I# ix) =
-  ST $ \s -> case readUnliftedArray# arr ix s of
-    (# s', a #) -> (# s', fromUnlifted# a #)
+readSmallUnliftedArray# (SmallMutableUnliftedArray# mary) i s
+  = case Exts.readSmallArray# mary i s of _ { (# s', a #) ->
+    case a of _ { DEFAULT__ ->
+      (# s', unsafeCoerce# a #)}}
 ```
 
-With the above definition of `readUnliftedArray#`, GHC rejiggers things and comes
-up with the following Core:
-
-```
-readUnliftedArray1_ra6c
-  :: forall a s.
-     PrimUnlifted a =>
-     MutableUnliftedArray_ s a (Unlifted a)
-     -> Int -> State# s -> (# State# s, a #)
-[GblId,
- Arity=4,
- Caf=NoCafRefs,
- Str=<L,1*U(A,1*C1(U))><S,1*U(U)><S,1*U(U)><L,U>,
- Unf=OtherCon []]
-readUnliftedArray1_ra6c
-  = \ (@ a_a6FT)
-      (@ s_a6FU)
-      ($dPrimUnlifted_a6FW :: PrimUnlifted a_a6FT)
-      (eta_X2C :: MutableUnliftedArray_ s_a6FU a_a6FT (Unlifted a_a6FT))
-      (eta1_X5d :: Int)
-      (eta2_X2 :: State# s_a6FU) ->
-      case eta_X2C of { MutableUnliftedArray arr_a57v ->
-      case eta1_X5d of { I# ix_a57w ->
-      case Exts.readArray#
-             @ s_a6FU
-             @ Exts.Any
-             (arr_a57v
-              `cast` (Data.Primitive.Unlifted.Array.Primops.N:MutableUnliftedArray#[0]
-                          <s_a6FU>_N <Unlifted a_a6FT>_R
-                      :: MutableUnliftedArray# s_a6FU (Unlifted a_a6FT)
-                         ~R# Exts.MutableArray# s_a6FU Exts.Any))
-             ix_a57w
-             eta2_X2
-      of
-      { (# ipv_sT3, ipv1_sT4 #) ->
-      case ipv1_sT4
-           `cast` (UnsafeCo representational Exts.Any (Unlifted a_a6FT)
-                   :: Exts.Any ~R# Unlifted a_a6FT)
-      of wild2_Xa
-      { __DEFAULT ->
-      (# ipv_sT3, fromUnlifted# @ a_a6FT $dPrimUnlifted_a6FW wild2_Xa #)
-      }
-      }
-      }
-      }
-```
-
-The problem is near the end: `case ipv1_sT4 `cast` ... of wild2_Xa`. This
-attempts to force the value extracted from the array. But that's an *unlifted*
-value, so forcing it will produce an unchecked exception. Yikes. What we do
-instead is define
+Since `a` has a *lifted* type there (even though it's really an *unlifted*
+object, it will be *entered*, which causes an unchecked exception. Ugh.
+It turns out that we get the code we want for `readSmallUnliftedArray#` by
+writing it like this:
 
 ```haskell
-readUnliftedArray# :: MutableUnliftedArray# s a -> Int# -> State# s -> (# State# s, a #)
-readUnliftedArray# (MutableUnliftedArray# mary) i s
-  = unsafeCoerce# (Exts.readArray# mary i s)
+readSmallUnliftedArray# :: SmallMutableUnliftedArray# s a -> Int# -> State# s -> (# State# s, a #)
+readSmallUnliftedArray# (SmallMutableUnliftedArray# mary) i s
+  = unsafeCoerce# (Exts.readSmallArray# mary i s)
 ```
 
-This seems to dodge the problem, at least in our testing thus far. We get the
-following Core, which is much more reasonable:
+Knowing this works, we `NOINLINE` it, hiding all the coercions from the
+optimizer and guaranteeing that we only need to do a deep dive into the Core
+for the modules defining the primops; coercion-related problems can't be
+introduced elsewhere.
 
-```
--- RHS size: {terms: 23, types: 50, coercions: 21, joins: 0/0}
-readUnliftedArray1_r9mM
-  :: forall a s.
-     PrimUnlifted a =>
-     MutableUnliftedArray_ s a (Unlifted a)
-     -> Int -> State# s -> (# State# s, a #)
-[GblId,
- Arity=4,
- Caf=NoCafRefs,
- Str=<L,1*U(A,1*C1(U))><S,1*U(U)><S,1*U(U)><L,U>,
- Unf=OtherCon []]
-readUnliftedArray1_r9mM
-  = \ (@ a_a5X9)
-      (@ s_a5Xa)
-      ($dPrimUnlifted_a5Xc :: PrimUnlifted a_a5X9)
-      (eta_X2C :: MutableUnliftedArray_ s_a5Xa a_a5X9 (Unlifted a_a5X9))
-      (eta1_X5d :: Int)
-      (eta2_X2 :: State# s_a5Xa) ->
-      case eta_X2C of { MutableUnliftedArray arr_a32J ->
-      case eta1_X5d of { I# ix_a32K ->
-      case (Exts.readArray#
-              @ s_a5Xa
-              @ Exts.Any
-              (arr_a32J
-               `cast` (Data.Primitive.Unlifted.Array.Primops.N:MutableUnliftedArray#[0]
-                           <s_a5Xa>_N <Unlifted a_a5X9>_R
-                       :: MutableUnliftedArray# s_a5Xa (Unlifted a_a5X9)
-                          ~R# Exts.MutableArray# s_a5Xa Exts.Any))
-              ix_a32K
-              eta2_X2)
-           `cast` (((#,#)
-                      <'Exts.TupleRep '[]>_R
-                      (UnsafeCo representational 'Exts.LiftedRep 'Exts.UnliftedRep)
-                      <State# s_a5Xa>_R
-                      (UnsafeCo representational Exts.Any (Unlifted a_a5X9)))_R
-                   :: (# State# s_a5Xa, Exts.Any #)
-                      ~R# (# State# s_a5Xa, Unlifted a_a5X9 #))
-      of
-      { (# ipv_s77D, ipv1_s77E #) ->
-      (# ipv_s77D,
-         fromUnlifted# @ a_a5X9 $dPrimUnlifted_a5Xc ipv1_s77E #)
-      }
-      }
-      }
-```
+For `Data.Primitive.Unlifted.Array.Primops`, we take a different approach.  An
+`ArrayArray#` can actually hold unlifted things, so we use that to represent
+`UnliftedArray#`, letting almost everything `INLINE`. Unfortunately, some
+`Array#` operations aren't available for `ArrayArray#`. But fortunately, an
+`ArrayArray#` is actually the same as an `Array#` under the hood! So we can
+`unsafeCoerce#` primops for `Array#` to work with `ArrayArray#`. In the very
+few cases where that involves coercing between lifted and unlifted types, we
+`NOINLINE`.

--- a/src/Data/Primitive/Unlifted/Weak/Primops.hs
+++ b/src/Data/Primitive/Unlifted/Weak/Primops.hs
@@ -7,6 +7,10 @@
 {-# language TypeFamilies #-}
 {-# language UnliftedNewtypes #-}
 
+-- See UnsafeCoercions.md for an explanation of why we coerce
+-- things the way we do here, and why some operations are marked
+-- NOINLINE.
+
 -- | "Primops" for weak references from (lifted or unlifted) values
 -- to unlifted values. Several of these use a slightly different
 -- interface than the underlying GHC primops. I have a GHC proposal
@@ -46,7 +50,7 @@ mkWeakFromUnliftedToUnlifted#
   :: forall (k :: TYPE 'UnliftedRep) (v :: TYPE 'UnliftedRep) c.
      k -> v -> (State# RealWorld -> (# State# RealWorld, c #))
   -> State# RealWorld -> (# State# RealWorld, UnliftedWeak# v #)
-{-# INLINE mkWeakFromUnliftedToUnlifted# #-}
+{-# NOINLINE mkWeakFromUnliftedToUnlifted# #-}
 mkWeakFromUnliftedToUnlifted# k v finalizer s =
   case mkWeak# k (unsafeCoerce# v) finalizer s of
     (# s', w #) -> (# s', UnliftedWeak# w #)
@@ -55,7 +59,7 @@ mkWeakFromUnliftedToUnlifted# k v finalizer s =
 mkWeakFromUnliftedToUnliftedNoFinalizer#
   :: forall (k :: TYPE 'UnliftedRep) (v :: TYPE 'UnliftedRep).
      k -> v -> State# RealWorld -> (# State# RealWorld, UnliftedWeak# v #)
-{-# INLINE mkWeakFromUnliftedToUnliftedNoFinalizer# #-}
+{-# NOINLINE mkWeakFromUnliftedToUnliftedNoFinalizer# #-}
 mkWeakFromUnliftedToUnliftedNoFinalizer# k v s =
   case mkWeakNoFinalizer# k (unsafeCoerce# v) s of
     (# s', w #) -> (# s', UnliftedWeak# w #)
@@ -67,7 +71,7 @@ mkWeakToUnlifted#
   :: forall k (v :: TYPE 'UnliftedRep) c.
      k -> v -> (State# RealWorld -> (# State# RealWorld, c #))
   -> State# RealWorld -> (# State# RealWorld, UnliftedWeak# v #)
-{-# INLINE mkWeakToUnlifted# #-}
+{-# NOINLINE mkWeakToUnlifted# #-}
 mkWeakToUnlifted# k v finalizer s =
   case mkWeak# k (unsafeCoerce# v) finalizer s of
     (# s', w #) -> (# s', UnliftedWeak# w #)
@@ -76,7 +80,7 @@ mkWeakToUnlifted# k v finalizer s =
 mkWeakToUnliftedNoFinalizer#
   :: forall k (v :: TYPE 'UnliftedRep).
      k -> v -> State# RealWorld -> (# State# RealWorld, UnliftedWeak# v #)
-{-# INLINE mkWeakToUnliftedNoFinalizer# #-}
+{-# NOINLINE mkWeakToUnliftedNoFinalizer# #-}
 mkWeakToUnliftedNoFinalizer# k v s =
   case mkWeakNoFinalizer# k (unsafeCoerce# v) s of
     (# s', w #) -> (# s', UnliftedWeak# w #)
@@ -108,7 +112,7 @@ deRefUnliftedWeak#
   :: UnliftedWeak# v
   -> State# RealWorld
   -> (# State# RealWorld, (# (##) | v #) #)
-{-# INLINE deRefUnliftedWeak# #-}
+{-# NOINLINE deRefUnliftedWeak# #-}
 deRefUnliftedWeak# (UnliftedWeak# w) s =
   case unsafeCoerce# (deRefWeak# w s) of
     (# s', flag, p #) -> case flag of


### PR DESCRIPTION
* Use `NOINLINE` to make sure unsafe coercions don't float around
and cause trouble.
* Use `ArrayArray#` operations to avoid needing to `NOINLINE` most
  (large) array operations.