### PR TITLE
allow building with ghc 9.2.1

### DIFF
--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: primitive-unlifted
-version: 0.1.3.0
+version: 0.1.3.1
 synopsis: Primitive GHC types with unlifted types inside
 description:
   Primitive GHC types with unlifted types inside. There used
@@ -25,7 +25,7 @@ library
     Data.Primitive.Unlifted.Array
   build-depends:
     , base >=4.11.1.0 && <5
-    , bytestring >=0.10.8.2 && <0.11
+    , bytestring >=0.10.8.2 && <0.12
     , primitive >= 0.7 && <0.8
     , text-short >=0.1.3 && <0.2
   hs-source-dirs: src

--- a/src/Data/Primitive/Unlifted/Class.hs
+++ b/src/Data/Primitive/Unlifted/Class.hs
@@ -2,6 +2,8 @@
 {-# language UnboxedTuples #-}
 {-# language TypeFamilies #-}
 {-# language ScopedTypeVariables #-}
+{-# language CPP #-}
+{-# language DataKinds #-}
 
 module Data.Primitive.Unlifted.Class
   ( PrimUnlifted(..)
@@ -16,15 +18,24 @@ import GHC.MVar (MVar(..))
 import GHC.IORef (IORef(..))
 import GHC.STRef (STRef(..))
 import GHC.Exts (State#,MutableByteArray#,ByteArray#,Int#)
-import GHC.Exts (ArrayArray#,MutableArrayArray#,RuntimeRep(UnliftedRep))
+import GHC.Exts (ArrayArray#,MutableArrayArray#)
 import GHC.Exts (MVar#,MutVar#,RealWorld)
 import GHC.Exts (TYPE,unsafeCoerce#)
 
 import qualified Data.Primitive.MVar as PM
 import qualified GHC.Exts as Exts
 
+-- In GHC 9.2 the UnliftedRep constructor of RuntimeRep was removed
+-- and replaced with a type synonym
+#if __GLASGOW_HASKELL__  >= 902
+import GHC.Exts (UnliftedRep)
+#else
+import GHC.Exts (RuntimeRep(UnliftedRep))
+type UnliftedRep = 'UnliftedRep
+#endif
+
 class PrimUnlifted a where
-  type Unlifted a :: TYPE 'UnliftedRep
+  type Unlifted a :: TYPE UnliftedRep
   toUnlifted# :: a -> Unlifted a
   fromUnlifted# :: Unlifted a -> a
   writeUnliftedArray# ::


### PR DESCRIPTION
- bump bytestring dependency to allow 0.11
- adapt to removal of UnliftedRep constructor of RuntimeRep