### PR TITLE
bump bytestring upperbound for ghc-9.8

### DIFF
--- a/primitive-unlifted.cabal
+++ b/primitive-unlifted.cabal
@@ -44,7 +44,7 @@ library
     Data.Primitive.Unlifted.Type
   build-depends:
     , base >=4.17.1.0 && <5
-    , bytestring >=0.10.8.2 && <0.12
+    , bytestring >=0.10.8.2 && <0.13
     , primitive >= 0.7 && <0.10
     , text-short >=0.1.3 && <0.2
     , array


### PR DESCRIPTION
closes #39